### PR TITLE
Modernize tech stack: CMake, C++17, dark theme, SVG toolbar, status bar

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,0 +1,102 @@
+cmake_minimum_required(VERSION 3.16)
+project(NetworkDesigner VERSION 1.0 LANGUAGES CXX)
+
+set(CMAKE_CXX_STANDARD 17)
+set(CMAKE_CXX_STANDARD_REQUIRED ON)
+
+set(CMAKE_AUTOMOC ON)
+set(CMAKE_AUTOUIC ON)
+set(CMAKE_AUTORCC ON)
+
+# Prefer Qt6, fall back to Qt5
+find_package(Qt6 QUIET COMPONENTS Core Gui Widgets Xml)
+if(Qt6_FOUND)
+    set(QT_VERSION_MAJOR 6)
+    set(QT_LIBS Qt6::Core Qt6::Gui Qt6::Widgets Qt6::Xml)
+    message(STATUS "Using Qt6")
+else()
+    find_package(Qt5 REQUIRED COMPONENTS Core Gui Widgets Xml)
+    set(QT_VERSION_MAJOR 5)
+    set(QT_LIBS Qt5::Core Qt5::Gui Qt5::Widgets Qt5::Xml)
+    message(STATUS "Using Qt5")
+endif()
+
+set(SOURCES
+    main.cpp
+    networkdesigner.cpp
+    Network.cpp
+    Neuron.cpp
+    Synapse.cpp
+    NeuronSynapse.h
+    DesignPlan.cpp
+    NetworkDesignerParser.cpp
+    EvenementHandler.cpp
+    SignalsSlotsConnector.cpp
+    UpdateBlock.cpp
+    UpdateSchedulingPlan.cpp
+    Computer.cpp
+    Simulation.cpp
+    SimulationActivity.cpp
+    SimulationAttractorsAndBasinsOfAttraction.cpp
+    SimulationAttractorsAndBasinsOfAttraction2.cpp
+    SimulationChangement.cpp
+    SimulationDiffusion.cpp
+    NetworkState.cpp
+    NetworkState2.cpp
+    NetworkStatesSet.cpp
+    SetOfNetworkStatesSet.cpp
+    BlockSelector.cpp
+    pCalculateTransitions.cpp
+    random-singleton.cpp
+)
+
+set(HEADERS
+    networkdesigner.h
+    Network.h
+    NeuronSynapse.h
+    designplan.h
+    NetworkDesignerParser.h
+    EvenementHandler.h
+    SignalsSlotsConnector.h
+    UpdateBlock.h
+    UpdateSchedulingPlan.h
+    Computer.h
+    Simulation.h
+    SimulationActivity.h
+    SimulationAttractorsAndBasinsOfAttraction.h
+    SimulationAttractorsAndBasinsOfAttraction2.h
+    SimulationChangement.h
+    SimulationDiffusion.h
+    NetworkState.h
+    NetworkState2.h
+    NetworkStatesSet.h
+    SetOfNetworkStatesSet.h
+    BlockSelector.h
+    pCalculateTransitions.h
+    random-singleton.h
+    constFile.h
+)
+
+set(FORMS
+    mainWindow.ui
+    networkdesigner.ui
+)
+
+set(RESOURCES
+    resources.qrc
+)
+
+add_executable(${PROJECT_NAME}
+    ${SOURCES}
+    ${HEADERS}
+    ${FORMS}
+    ${RESOURCES}
+)
+
+target_link_libraries(${PROJECT_NAME} PRIVATE ${QT_LIBS})
+
+target_compile_options(${PROJECT_NAME} PRIVATE
+    $<$<CXX_COMPILER_ID:GNU,Clang>:-Wall -Wextra -Wpedantic>
+)
+
+install(TARGETS ${PROJECT_NAME} RUNTIME DESTINATION bin)

--- a/Computer.cpp
+++ b/Computer.cpp
@@ -1,318 +1,212 @@
 #include "Computer.h"
+#include <algorithm>
 
-Computer::Computer()
+Computer::Computer() = default;
+Computer::~Computer() = default;
+
+Computer::Computer(const Computer& computer)
+    : network(new Network(*computer.getNetwork()))
+    , updateSchedulingPlan(new UpdateSchedulingPlan(*computer.getUpdateSchedulingPlan()))
+    , nb_iterations(computer.getNbIterations())
+    , ui(computer.getUi())
+    , repaintDesign(false)
 {
+    Random::Uniform<double>(0.0, 1.0);
+    connect(this, SIGNAL(setProgressBarValue_Signal(int)), ui->progressBar, SLOT(setValue(int)));
 }
 
-Computer::Computer(const Computer& computer){
-		network = new Network(*(computer.getNetwork()));
-		updateSchedulingPlan = new UpdateSchedulingPlan(*(computer.getUpdateSchedulingPlan()));
-		nb_iterations = computer.getNbIterations();
-		Random::Uniform<double>(0.0,1.0);
-		ui = computer.getUi();
-		connect(this, SIGNAL(setProgressBarValue_Signal(int)), ui->progressBar, SLOT(setValue(int)));
-		repaintDesign = false;
-}
-
-Computer::Computer(Network * network, UpdateSchedulingPlan * updateSchedulingPlan, Ui::MainWindow * ui){
-	this->network = network;
-	this->updateSchedulingPlan = updateSchedulingPlan;
-	//this->simulation = simulation;
-	nb_iterations = ui->sbUpdatesNumber->value();
-	this->ui = ui;
-	Random::Uniform<double>(0.0,1.0);
-	connect(this, SIGNAL(setProgressBarValue_Signal(int)), ui->progressBar, SLOT(setValue(int)));
-	repaintDesign = true;
-}
-
-Computer::~Computer()
+Computer::Computer(Network* network, UpdateSchedulingPlan* updateSchedulingPlan, Ui::MainWindow* ui)
+    : network(network)
+    , updateSchedulingPlan(updateSchedulingPlan)
+    , nb_iterations(ui->sbUpdatesNumber->value())
+    , ui(ui)
+    , repaintDesign(true)
 {
+    Random::Uniform<double>(0.0, 1.0);
+    connect(this, SIGNAL(setProgressBarValue_Signal(int)), ui->progressBar, SLOT(setValue(int)));
 }
 
-Ui::MainWindow * Computer::getUi() const{
-	return ui;
+Ui::MainWindow* Computer::getUi() const { return ui; }
+
+void Computer::setNetwork(Network* n)                               { network = n; }
+Network* Computer::getNetwork() const                               { return network; }
+void Computer::setUpdateSchedulingPlan(UpdateSchedulingPlan* usp)  { updateSchedulingPlan = usp; }
+UpdateSchedulingPlan* Computer::getUpdateSchedulingPlan() const    { return updateSchedulingPlan; }
+int Computer::getNbIterations() const                               { return nb_iterations; }
+void Computer::setNbIterations(int n)                               { nb_iterations = n; }
+void Computer::stopComputing()                                      { stop = true; }
+
+// ── helpers ──────────────────────────────────────────────────────────────────
+
+void Computer::setProgressBarValue(int value) {
+    emit setProgressBarValue_Signal(value);
 }
 
-/*
- * Network's setter
- */
-void Computer::setNetwork(Network * network){
-	this->network = network;
+void Computer::setStateOfTheNetwork(NetworkState* networkState) {
+    for (int i = 0; i < network->getNbNeurons(); ++i)
+        network->getNeuron(i)->setState(networkState->getState(i));
 }
 
-/*
- * Network's getter
- */
-Network * Computer::getNetwork() const{
-	return network;
+// Returns the temperature to use for neuron j.
+double Computer::neuronTemperature(int j) const {
+    return network->getUniformalTemperature()
+        ? network->getTemperature()
+        : network->getNeuron(j)->getTemperature();
 }
 
-/*
- * Simulation's setter
-
-void Computer::setSimulation(Simulation * simulation){
-	this->simulation = simulation;
-}
-*/
-/*
- * Simulation's getter
-
-Simulation * Computer::getSimulation() const{
-	return simulation;
-}
-*/
-
-/*
- * UpdateScheduler's setter
- */
-void Computer::setUpdateSchedulingPlan(UpdateSchedulingPlan * updateSchedulingPlan){
-	this->updateSchedulingPlan = updateSchedulingPlan;
+// Repaint + throttle when speed < 100%.
+void Computer::maybeRepaint() {
+    if (!repaintDesign) return;
+    if (ui->sbSpeedPercent->value() != 100) {
+        ui->frmDesign->repaint();
+        usleep(100'000 - ui->sbSpeedPercent->value() * 1'000);
+    }
 }
 
-/*
- * UpdateScheduler's getter
- */
-UpdateSchedulingPlan * Computer::getUpdateSchedulingPlan() const{
-	return updateSchedulingPlan;
+// Apply synchrony-gated compute+substitute for a single neuron (sequential mode).
+void Computer::computeAndSubstitute(int j, double syncRate) {
+    if (Random::Uniform() <= syncRate) {
+        network->getNeuron(j)->compute(neuronTemperature(j));
+        network->getNeuron(j)->substitute();
+    }
 }
 
-/*
- * Compute using block sequential scheduling
- */
-void Computer::computeBS(){
-	stop = false;
-	double synchronyRate = ui->dsbSynchronyRate->value();
+// ── Parallel update ───────────────────────────────────────────────────────────
 
-	//network->setUniformalTemperature(true);
-	int nb_blocks = updateSchedulingPlan->getNb_blocks();
-	double rnd;
-	for(int k=0; k < nb_iterations; k++){
-		if(stop) return;
-		for(int i=0;i< nb_blocks;i++){
+void Computer::computeP() {
+    stop = false;
+    const double syncRate = ui->dsbSynchronyRate->value();
+    const int n = network->getNbNeurons();
 
-			UpdateBlock* ub = updateSchedulingPlan->getUpdateBlock(i);
-			if(ub->getUpdateMethods() == COMPUTE){
-				// All neuron compute their new state using a parallele scheme
-				for(int j=0; j < ub->getSize(); j++){
-					rnd = Random::Uniform();//(double)rand() / ((double)RAND_MAX+1.0);
-					if(rnd <= synchronyRate){
-						if(not network->getUniformalTemperature()) network->getNeuron(ub->getNeuronIndex(j))->compute(network->getNeuron(ub->getNeuronIndex(j))->getTemperature());
-						else network->getNeuron(ub->getNeuronIndex(j))->compute(network->getTemperature());
-					}
-				}
-				// When all is done theNewState is set
-				for(int j=0; j < ub->getSize(); j++)
-								network->getNeuron(ub->getNeuronIndex(j))->substitute();
-			}
+    for (int iter = 0; iter < nb_iterations; ++iter) {
+        if (stop) return;
 
-			else if(ub->getUpdateMethods() == FIXE_1){
-				for(int j=0; j < ub->getSize(); j++){
-					rnd = Random::Uniform();
-					if(rnd <= synchronyRate)
-								network->getNeuron(ub->getNeuronIndex(j))->setState(true);
-				}
-			}
+        for (int j = 0; j < n; ++j)
+            if (Random::Uniform() <= syncRate)
+                network->getNeuron(j)->compute(neuronTemperature(j));
 
-			else if(ub->getUpdateMethods() == FIXE_0){
-				for(int j=0; j < ub->getSize(); j++){
-					rnd = Random::Uniform();
-					if(rnd <= synchronyRate)
-								network->getNeuron(ub->getNeuronIndex(j))->setState(false);
-				}
-			}
+        for (int j = 0; j < n; ++j)
+            network->getNeuron(j)->substitute();
 
-			else if(ub->getUpdateMethods() == FIXE_01){
-				for(int j=0; j < ub->getSize(); j++){
-					rnd = Random::Uniform();
-					if(rnd <= synchronyRate)
-								network->getNeuron(ub->getNeuronIndex(j))->setState((bool)(j%2));
-				}
-			}
-
-			else if(ub->getUpdateMethods() == FIXE_10){
-				for(int j=0; j < ub->getSize(); j++){
-					rnd = Random::Uniform();
-					if(rnd <= synchronyRate)
-								network->getNeuron(ub->getNeuronIndex(j))->setState((bool)((j+1)%2));
-				}
-			}
-
-			else if(ub->getUpdateMethods() == RANDOMLY){
-				for(int j=0; j < ub->getSize(); j++){
-					rnd = Random::Uniform();
-					if(rnd <= synchronyRate){
-						if(Random::Uniform()<0.5)
-								network->getNeuron(ub->getNeuronIndex(j))->setState(false);
-						else
-								network->getNeuron(ub->getNeuronIndex(j))->setState(true);
-					}
-				}
-			}
-			emit tick();
-		}
-		// Mark a little pause and refresh th designPlan widget
-		if(repaintDesign){
-			if(ui->sbSpeedPercent->value()!=100){
-				ui->frmDesign->repaint();
-				usleep(100000-ui->sbSpeedPercent->value()*1000);
-			}
-		}
-		//emit tick();
-	}
-	if(repaintDesign)	ui->frmDesign->repaint();
+        maybeRepaint();
+        emit tick();
+    }
+    if (repaintDesign) ui->frmDesign->repaint();
 }
 
-/*
- * Compute using block parallel scheduling
- */
-void Computer::computeBP(){
-	stop = false;
-	double synchronyRate = ui->dsbSynchronyRate->value();
+// ── Sequential update ─────────────────────────────────────────────────────────
 
-	network->setUniformalTemperature(true);
-	int nb_blocks = updateSchedulingPlan->getNb_blocks();
-	UpdateBlock* ub;
-	double rnd;
-	for(int i=0;i< nb_iterations;i++){
-		if(stop) return;
-			// All neuron compute their new state using a parallele scheme
-			for(int j=0; j < nb_blocks; j++){
-				ub = updateSchedulingPlan->getUpdateBlock(j);
-				rnd = Random::Uniform();
-				if(rnd <= synchronyRate){
-					if(ub->getUpdateMethods() == COMPUTE){
-						if(not network->getUniformalTemperature()) network->getNeuron(ub->getNeuronIndex(i%ub->getSize()))->compute(network->getNeuron(ub->getNeuronIndex(i%ub->getSize()))->getTemperature());
-						else network->getNeuron(ub->getNeuronIndex(i%ub->getSize()))->compute(network->getTemperature());
-					}
-					else if(ub->getUpdateMethods() == FIXE_1){
-							network->getNeuron(ub->getNeuronIndex(i%ub->getSize()))->setTheNewState(true);
-					}
+void Computer::computeS() {
+    stop = false;
+    const double syncRate = ui->dsbSynchronyRate->value();
+    const int n = network->getNbNeurons();
 
-					else if(ub->getUpdateMethods() == FIXE_0){
-						network->getNeuron(ub->getNeuronIndex(i%ub->getSize()))->setTheNewState(false);
-					}
+    for (int iter = 0; iter < nb_iterations; ++iter) {
+        if (stop) return;
 
-					else if(ub->getUpdateMethods() == FIXE_01){
-						network->getNeuron(ub->getNeuronIndex(i%ub->getSize()))->setTheNewState((bool)(i%2));
-					}
-
-					else if(ub->getUpdateMethods() == FIXE_10){
-						network->getNeuron(ub->getNeuronIndex(i%ub->getSize()))->setTheNewState((bool)((i+1)%2));
-					}
-
-					else if(ub->getUpdateMethods() == RANDOMLY){
-						if(Random::Uniform()<0.5)
-							network->getNeuron(ub->getNeuronIndex(i%ub->getSize()))->setTheNewState(false);
-						else
-							network->getNeuron(ub->getNeuronIndex(i%ub->getSize()))->setTheNewState(true);
-
-					}
-				}
-			}
-			// When all is done theNewState is set
-			for(int j=0; j < nb_blocks; j++){
-				ub = updateSchedulingPlan->getUpdateBlock(j);
-				network->getNeuron(ub->getNeuronIndex(i%ub->getSize()))->substitute();
-			}
-		if(repaintDesign){
-			if(ui->sbSpeedPercent->value()!=100){
-						ui->frmDesign->repaint();
-						usleep(100000-ui->sbSpeedPercent->value()*1000);
-			}
-		}
-			emit tick();
-	}
-	if(repaintDesign) ui->frmDesign->repaint();
+        for (int j = 0; j < n; ++j) {
+            computeAndSubstitute(j, syncRate);
+            maybeRepaint();
+        }
+        emit tick();
+    }
+    if (repaintDesign) ui->frmDesign->repaint();
 }
 
-/*
- * Compute using parallel scheduling
- */
-void Computer::computeP(){
-	stop = false;
-	double synchronyRate = ui->dsbSynchronyRate->value();
-	double rnd;
+// ── Block Sequential update ───────────────────────────────────────────────────
 
-	for(int i=0;i< nb_iterations;i++){
-		if(stop) return;
-		// All neuron compute their new state using a parallele scheme
-		for(int j=0; j < network->getNbNeurons(); j++){
-			rnd = Random::Uniform();//(double)rand() / ((double)RAND_MAX+1.0);
-			if(rnd <= synchronyRate){
-				if(not network->getUniformalTemperature()) network->getNeuron(j)->compute(network->getNeuron(j)->getTemperature());
-				else network->getNeuron(j)->compute(network->getTemperature());
-			}
-		}
-		// When all is done theNewState is set
-		for(int j=0; j < network->getNbNeurons(); j++){
-							network->getNeuron(j)->substitute();
-		}
-		if(repaintDesign){
-			if(ui->sbSpeedPercent->value()!=100){
-				ui->frmDesign->repaint();
-				usleep(100000-ui->sbSpeedPercent->value()*1000);
-			}
-		}
-		emit tick();
-	}
-	if(repaintDesign) ui->frmDesign->repaint();
+void Computer::applyBlockMethod(UpdateBlock* ub, double syncRate, int iterIndex) {
+    const int method = ub->getUpdateMethods();
+    const int sz     = ub->getSize();
+
+    auto neuronAt = [&](int j) { return network->getNeuron(ub->getNeuronIndex(j)); };
+    auto gated    = [&](int j, auto action) {
+        if (Random::Uniform() <= syncRate) action(neuronAt(j));
+    };
+
+    switch (method) {
+    case COMPUTE:
+        for (int j = 0; j < sz; ++j)
+            gated(j, [&](Neuron* n) { n->compute(neuronTemperature(ub->getNeuronIndex(j))); });
+        for (int j = 0; j < sz; ++j)
+            neuronAt(j)->substitute();
+        break;
+
+    case FIXE_1:
+        for (int j = 0; j < sz; ++j)
+            gated(j, [](Neuron* n) { n->setState(true); });
+        break;
+
+    case FIXE_0:
+        for (int j = 0; j < sz; ++j)
+            gated(j, [](Neuron* n) { n->setState(false); });
+        break;
+
+    case FIXE_01:
+        for (int j = 0; j < sz; ++j)
+            gated(j, [j](Neuron* n) { n->setState(static_cast<bool>(j % 2)); });
+        break;
+
+    case FIXE_10:
+        for (int j = 0; j < sz; ++j)
+            gated(j, [j](Neuron* n) { n->setState(static_cast<bool>((j + 1) % 2)); });
+        break;
+
+    case RANDOMLY:
+        for (int j = 0; j < sz; ++j)
+            gated(j, [](Neuron* n) { n->setState(Random::Uniform() >= 0.5); });
+        break;
+
+    default:
+        break;
+    }
 }
 
-/*
- * Compute using sequential scheduling
- */
-void Computer::computeS(){
-	stop = false;
-	double synchronyRate = ui->dsbSynchronyRate->value();
-	double rnd;
-	for(int i=0;i< nb_iterations;i++){
-		if(stop) return;
-		// All neuron compute their new state using a parallele scheme
-		for(int j=0; j < network->getNbNeurons(); j++){
-			rnd = Random::Uniform();//(double)rand() / ((double)RAND_MAX+1.0);
-			if(rnd <= synchronyRate){
-				if(not network->getUniformalTemperature()){
-					 network->getNeuron(j)->compute(network->getNeuron(j)->getTemperature());
-					 network->getNeuron(j)->substitute();
-				}
-				else {
-					network->getNeuron(j)->compute(network->getTemperature());
-					network->getNeuron(j)->substitute();
-				}
-			}
-			if(repaintDesign){
-				if(ui->sbSpeedPercent->value()!=100){
-					ui->frmDesign->repaint();
-					usleep(100000-ui->sbSpeedPercent->value()*1000);
-				}
-			}
-		}
-		emit tick();
-	}
-	if(repaintDesign) ui->frmDesign->repaint();
+void Computer::computeBS() {
+    stop = false;
+    const double syncRate  = ui->dsbSynchronyRate->value();
+    const int    nb_blocks = updateSchedulingPlan->getNb_blocks();
+
+    for (int iter = 0; iter < nb_iterations; ++iter) {
+        if (stop) return;
+
+        for (int i = 0; i < nb_blocks; ++i) {
+            applyBlockMethod(updateSchedulingPlan->getUpdateBlock(i), syncRate, iter);
+            emit tick();
+        }
+        maybeRepaint();
+    }
+    if (repaintDesign) ui->frmDesign->repaint();
 }
 
-int Computer::getNbIterations() const{
-	return nb_iterations;
-}
+// ── Block Parallel update ─────────────────────────────────────────────────────
 
-void Computer::setNbIterations(int nb_iterations){
-	this->nb_iterations = nb_iterations;
-}
+void Computer::computeBP() {
+    stop = false;
+    const double syncRate  = ui->dsbSynchronyRate->value();
+    const int    nb_blocks = updateSchedulingPlan->getNb_blocks();
 
-/*
- * Change the value of the progress bar
- */
-void Computer::setProgressBarValue(int value){
-	emit setProgressBarValue_Signal(value);
-}
+    network->setUniformalTemperature(true);
 
-void Computer::stopComputing(){
-	stop = true;
-}
+    for (int iter = 0; iter < nb_iterations; ++iter) {
+        if (stop) return;
 
-void Computer::setStateOfTheNetwork(NetworkState* networkState){
-	for(int i=0; i<this->getNetwork()->getNbNeurons(); i++){
-		this->getNetwork()->getNeuron(i)->setState(networkState->getState(i));
-	}
+        // Compute phase (all blocks)
+        for (int j = 0; j < nb_blocks; ++j) {
+            auto* ub  = updateSchedulingPlan->getUpdateBlock(j);
+            int   idx = iter % ub->getSize();
+            if (Random::Uniform() <= syncRate)
+                applyBlockMethod(ub, syncRate, iter);
+        }
+
+        // Substitute phase (all blocks)
+        for (int j = 0; j < nb_blocks; ++j) {
+            auto* ub = updateSchedulingPlan->getUpdateBlock(j);
+            network->getNeuron(ub->getNeuronIndex(iter % ub->getSize()))->substitute();
+        }
+
+        maybeRepaint();
+        emit tick();
+    }
+    if (repaintDesign) ui->frmDesign->repaint();
 }

--- a/Computer.h
+++ b/Computer.h
@@ -51,6 +51,12 @@ public:
 	void computeP();
 	void computeS();
 
+private:
+	double neuronTemperature(int j) const;
+	void   maybeRepaint();
+	void   computeAndSubstitute(int j, double syncRate);
+	void   applyBlockMethod(UpdateBlock* ub, double syncRate, int iterIndex);
+
 signals:
 	void tick();
 	void setProgressBarValue_Signal(int);

--- a/DesignPlan.cpp
+++ b/DesignPlan.cpp
@@ -1,6 +1,7 @@
 #include "designplan.h"
 #include <QtGui/QPainter>
 #include <QtGui/QLinearGradient>
+#include <QtGui/QCursor>
 #include "networkdesigner.h"
 #include <iostream>
 using namespace std;
@@ -181,6 +182,7 @@ void DesignPlan::mouseReleaseEvent(QMouseEvent * event){
 	synapseBaseNeuron = nullptr;
 	currentNeuron = nullptr;
 	currentSynapse = nullptr;
+	setCursor(Qt::ArrowCursor);
 
 	this->repaint();
 }
@@ -241,34 +243,51 @@ void DesignPlan::keyPressEvent( QKeyEvent * event ){
 void DesignPlan::mouseMoveEvent(QMouseEvent * event){
 	mouseX = event->x();
 	mouseY = event->y();
+
+	// Emit canvas world coordinates for the status bar
+	const int worldX = static_cast<int>((mouseX - transX) / scale);
+	const int worldY = static_cast<int>((mouseY - transY) / scale);
+	emit canvasMouseMoved(worldX, worldY);
+
 	double dX, dY;
-	if(currentNeuron!=nullptr){
-		dX = currentNeuron->getX() - (event->x()- transX)/scale;
-		dY = currentNeuron->getY() - (event->y()- transY)/scale;
-		currentNeuron->setXY((event->x()- transX)/scale, (event->y() - transY)/scale);
-		for(int i=0; i<network->getNbNeurons(); i++){
-			if((network->getNeuron(i)->getIndex()!=currentNeuron->getIndex()) and (network->getNeuron(i)->getSelected()))
-				network->getNeuron(i)->setXY(network->getNeuron(i)->getX()-dX ,network->getNeuron(i)->getY()-dY);
+	if (currentNeuron != nullptr) {
+		dX = currentNeuron->getX() - (event->x() - transX) / scale;
+		dY = currentNeuron->getY() - (event->y() - transY) / scale;
+		currentNeuron->setXY((event->x() - transX) / scale, (event->y() - transY) / scale);
+		for (int i = 0; i < network->getNbNeurons(); ++i) {
+			if (network->getNeuron(i)->getIndex() != currentNeuron->getIndex()
+			        && network->getNeuron(i)->getSelected())
+				network->getNeuron(i)->setXY(network->getNeuron(i)->getX() - dX,
+				                             network->getNeuron(i)->getY() - dY);
 		}
+		setCursor(Qt::ClosedHandCursor);
 		emit networkIsModified();
 		this->repaint();
-	} else if(currentSynapse != nullptr){
-		//dX = currentSynapse->getBaseNeuron()->getX() - (event->x()- transX)/scale;
-		//currentSynapse->setGExcentricity(currentSynapse->getGExcentricity() - ((float)dX/50000));
-		currentSynapse->setCX((event->x() - transX)/scale);
-		currentSynapse->setCY((event->y() - transY)/scale);
+	} else if (currentSynapse != nullptr) {
+		currentSynapse->setCX((event->x() - transX) / scale);
+		currentSynapse->setCY((event->y() - transY) / scale);
+		setCursor(Qt::SizeAllCursor);
 		emit networkIsModified();
 		this->repaint();
-	}
-	if(synapseBaseNeuron != nullptr){
-		this->repaint();
-	}
-	if((midX != -1)){
+	} else if (midX != -1) {
+		// Panning
 		transX += mouseX - midX;
 		transY += mouseY - midY;
 		midX = mouseX;
 		midY = mouseY;
+		setCursor(Qt::ClosedHandCursor);
 		this->repaint();
+	} else if (synapseBaseNeuron != nullptr) {
+		// Drawing synapse
+		setCursor(Qt::CrossCursor);
+		this->repaint();
+	} else {
+		// Hover: show pointer over neurons, crosshair over empty space
+		Neuron* hovered = network->getNeuron(
+		    static_cast<int>((event->x() - transX) / scale),
+		    static_cast<int>((event->y() - transY) / scale),
+		    static_cast<int>(12 / scale));
+		setCursor(hovered ? Qt::PointingHandCursor : Qt::ArrowCursor);
 	}
 }
 

--- a/DesignPlan.cpp
+++ b/DesignPlan.cpp
@@ -1,5 +1,6 @@
 #include "designplan.h"
 #include <QtGui/QPainter>
+#include <QtGui/QLinearGradient>
 #include "networkdesigner.h"
 #include <iostream>
 using namespace std;
@@ -275,16 +276,42 @@ void DesignPlan::mouseMoveEvent(QMouseEvent * event){
  * Paint the network and a representation of the synapse the user is currently building.
  */
 void DesignPlan::paintEvent(QPaintEvent * event){
-	QPainter painter(this);
-	if(loaded){
-		if(synapseBaseNeuron != nullptr){
-			painter.setPen(QPen(Qt::black, 2*scale, Qt::SolidLine, Qt::RoundCap));
-			painter.drawLine((int)(synapseBaseNeuron->getX()*scale + transX),(int)(synapseBaseNeuron->getY() * scale + transY), mouseX, mouseY);
-		}
-		if (network != nullptr)
-			network->drawMe(&painter, scale, transX, transY);
-	}
+    QPainter painter(this);
+    painter.setRenderHint(QPainter::Antialiasing, true);
+    painter.setRenderHint(QPainter::TextAntialiasing, true);
+    painter.setRenderHint(QPainter::SmoothPixmapTransform, true);
 
+    // Dark canvas background with subtle gradient
+    QLinearGradient bg(0, 0, width(), height());
+    bg.setColorAt(0.0, QColor(0x11, 0x11, 0x1b));
+    bg.setColorAt(1.0, QColor(0x18, 0x18, 0x25));
+    painter.fillRect(rect(), bg);
+
+    // Subtle dot grid
+    painter.setPen(QPen(QColor(0x31, 0x32, 0x44, 120), 1));
+    const int gridStep = static_cast<int>(40 * scale);
+    if (gridStep >= 10) {
+        int offX = static_cast<int>(transX) % gridStep;
+        int offY = static_cast<int>(transY) % gridStep;
+        for (int gx = offX; gx < width(); gx += gridStep)
+            for (int gy = offY; gy < height(); gy += gridStep)
+                painter.drawPoint(gx, gy);
+    }
+
+    if (loaded) {
+        // Synapse-under-construction preview line
+        if (synapseBaseNeuron != nullptr) {
+            QPen dashPen(QColor(0x89, 0xb4, 0xfa, 160), 1.8 * scale, Qt::DashLine, Qt::RoundCap);
+            painter.setPen(dashPen);
+            painter.drawLine(
+                QPointF(synapseBaseNeuron->getX() * scale + transX,
+                        synapseBaseNeuron->getY() * scale + transY),
+                QPointF(mouseX, mouseY));
+        }
+
+        if (network != nullptr)
+            network->drawMe(&painter, scale, transX, transY);
+    }
 }
 
 /*

--- a/Network.cpp
+++ b/Network.cpp
@@ -1,193 +1,142 @@
 #include "Network.h"
 #include "constFile.h"
 #include "random-singleton.h"
+#include <algorithm>
 #include <cmath>
 #include <iostream>
-using namespace std;
-
 
 Network::Network(double temperature)
+    : temperature(temperature)
+    , uniformalTemperature(true)
 {
-	
-	uniformalTemperature = true;
-	this->temperature = temperature;
-	Random::Uniform<double>(0.0,1.0);
+    Random::Uniform<double>(0.0, 1.0);
 }
 
-Network::Network(){
-	
-	temperature = 0.001;
-	uniformalTemperature = true;
-	Random::Uniform<double>(0.0,1.0);
-}
-
-Network::Network(const Network& network){
-	temperature = network.getTemperature();
-	uniformalTemperature = network.getUniformalTemperature();
-	Random::Uniform<double>(0.0,1.0);
-	
-	for(int i=0; i<network.getNbNeurons(); i++){
-		addNeuron(new Neuron(*network.getNeuron(i)));	
-	}
-	
-	for(int i=0; i<(int)neurons.size(); i++){
-		for(int j=0; j<network.getNeuron(i)->getNb_neighbors();j++){
-				getNeuron(i)->addSynapse(getNeuron(network.getNeuron(i)->getSynapse(j)->getFinalNeuron()->getIndex()), network.getNeuron(i)->getSynapseWeight(j), network.getNeuron(i)->getSynapseDelay(j));
-			getNeuron(i)->getSynapse(j)->setCX(network.getNeuron(i)->getSynapse(j)->getCX());
-			getNeuron(i)->getSynapse(j)->setCY(network.getNeuron(i)->getSynapse(j)->getCY());
-		}
-	}
-}
-
-void Network::addNetwork(Network * network){
-	int initial_nb_neurons = (int)neurons.size();
-	deselectAll();
-	for(int i=0; i<network->getNbNeurons(); i++){
-		addNeuron(new Neuron(*(network->getNeuron(i))));
-		getNeuron(initial_nb_neurons + i)->setSelected(true);
-	}
-	
-	for(int i=0; i<network->getNbNeurons(); i++){
-		for(int j=0; j<network->getNeuron(i)->getNb_neighbors();j++){
-				getNeuron(i+initial_nb_neurons)->addSynapse(getNeuron(network->getNeuron(i)->getSynapse(j)->getFinalNeuron()->getIndex()+initial_nb_neurons), network->getNeuron(i)->getSynapseWeight(j), network->getNeuron(i)->getSynapseDelay(j));
-				getNeuron(i+initial_nb_neurons)->getSynapse(j)->setCX(network->getNeuron(i)->getSynapse(j)->getCX());
-				getNeuron(i+initial_nb_neurons)->getSynapse(j)->setCY(network->getNeuron(i)->getSynapse(j)->getCY());
-		}
-	}
-}
-
-Network::~Network()
+Network::Network()
+    : temperature(0.001)
+    , uniformalTemperature(true)
 {
-	neurons.clear();
+    Random::Uniform<double>(0.0, 1.0);
 }
 
-/*
- * Nb_Neurons's getter
- */
-int Network::getNbNeurons() const{
-	return (int)neurons.size();
+Network::Network(const Network& other)
+    : temperature(other.temperature)
+    , uniformalTemperature(other.uniformalTemperature)
+{
+    Random::Uniform<double>(0.0, 1.0);
+
+    for (int i = 0; i < other.getNbNeurons(); ++i)
+        addNeuron(new Neuron(*other.getNeuron(i)));
+
+    for (int i = 0; i < getNbNeurons(); ++i) {
+        for (int j = 0; j < other.getNeuron(i)->getNb_neighbors(); ++j) {
+            auto* syn = other.getNeuron(i)->getSynapse(j);
+            getNeuron(i)->addSynapse(
+                getNeuron(syn->getFinalNeuron()->getIndex()),
+                other.getNeuron(i)->getSynapseWeight(j),
+                other.getNeuron(i)->getSynapseDelay(j));
+            getNeuron(i)->getSynapse(j)->setCX(syn->getCX());
+            getNeuron(i)->getSynapse(j)->setCY(syn->getCY());
+        }
+    }
 }
 
-/*
- * Uniformal Temperature's setter
- */
-void Network::setUniformalTemperature(bool uniformalTemperature){
-	this->uniformalTemperature = uniformalTemperature;
+Network::~Network() = default;
+
+void Network::addNetwork(Network* other) {
+    const int offset = getNbNeurons();
+    deselectAll();
+
+    for (int i = 0; i < other->getNbNeurons(); ++i) {
+        addNeuron(new Neuron(*other->getNeuron(i)));
+        getNeuron(offset + i)->setSelected(true);
+    }
+
+    for (int i = 0; i < other->getNbNeurons(); ++i) {
+        for (int j = 0; j < other->getNeuron(i)->getNb_neighbors(); ++j) {
+            auto* syn = other->getNeuron(i)->getSynapse(j);
+            getNeuron(offset + i)->addSynapse(
+                getNeuron(syn->getFinalNeuron()->getIndex() + offset),
+                other->getNeuron(i)->getSynapseWeight(j),
+                other->getNeuron(i)->getSynapseDelay(j));
+            getNeuron(offset + i)->getSynapse(j)->setCX(syn->getCX());
+            getNeuron(offset + i)->getSynapse(j)->setCY(syn->getCY());
+        }
+    }
 }
 
-/*
- * Uniformal Temperature's getter
- */
-bool Network::getUniformalTemperature() const{
-	return uniformalTemperature;
+// ── Getters / setters ─────────────────────────────────────────────────────────
+
+int  Network::getNbNeurons() const                       { return static_cast<int>(neurons.size()); }
+void Network::setTemperature(double t)                   { temperature = t; }
+double Network::getTemperature() const                   { return temperature; }
+void Network::setUniformalTemperature(bool u)            { uniformalTemperature = u; }
+bool Network::getUniformalTemperature() const            { return uniformalTemperature; }
+
+// ── Neuron access ─────────────────────────────────────────────────────────────
+
+Neuron* Network::getNeuron(int index) const {
+    if (index >= 0 && index < getNbNeurons())
+        return neurons[index].get();
+    return nullptr;
 }
 
-
-/*
- * Temperature's setter
- */
-void Network::setTemperature(double temperature){
-	this->temperature = temperature;
+Neuron* Network::getNeuron(int x, int y, int radius) const {
+    auto it = std::find_if(neurons.begin(), neurons.end(), [=](const auto& n) {
+        return std::abs(n->getX() - x) <= radius && std::abs(n->getY() - y) <= radius;
+    });
+    return it != neurons.end() ? it->get() : nullptr;
 }
 
-/*
- * Temperature's getter
- */
-double Network::getTemperature() const{
-	return temperature;
+Synapse* Network::getSynapse(int x, int y) const {
+    for (const auto& n : neurons)
+        for (int j = 0; j < n->getNb_neighbors(); ++j)
+            if (n->getSynapse(j)->selectable(x, y))
+                return n->getSynapse(j);
+    return nullptr;
 }
 
-/*
- * Deselect all the neurons
- */
-void Network::deselectAll(){
-	for (const auto& n : neurons) {
-		n->setSelected(false);
-		for (int j = 0; j < n->getNb_neighbors(); ++j)
-			n->getSynapse(j)->setSelected(false);
-	}
+void Network::addNeuron(Neuron* neuron) {
+    neuron->setIndex(getNbNeurons());
+    neurons.push_back(std::unique_ptr<Neuron>(neuron));
 }
 
-/*
- * Return a neuron base on its x and y and the radius
- */
-Neuron* Network::getNeuron(int x, int y, int radius) const{
-	for(int i=0; i< (int)neurons.size(); i++){
-		if((abs(neurons[i]->getX()-x) <= radius) and (abs(neurons[i]->getY()-y)<= radius)){
-			return neurons[i].get();
-		}
-	}
-	return nullptr;
+void Network::delNeuron(int index) {
+    if (!getNeuron(index)) return;
+
+    // Remove all synapses pointing to this neuron
+    for (int i = 0; i < getNbNeurons(); ++i) {
+        int si = getNeuron(i)->getSynapseByNeighborIndex(index);
+        if (si < getNeuron(i)->getNb_neighbors()) {
+            getNeuron(i)->delSynapseBySynapseIndex(si);
+            --i;
+        }
+    }
+
+    // Shift indices of neurons that come after
+    for (int i = index + 1; i < getNbNeurons(); ++i)
+        getNeuron(i)->setIndex(i - 1);
+
+    neurons.erase(neurons.begin() + index);
 }
 
-/*
- * Return a synapse based on the mouse x and y
- */
-Synapse * Network::getSynapse(int x, int y) const{
-	for(int i=0; i< (int)neurons.size(); i++){
-		for(int j=0; j < neurons[i]->getNb_neighbors();j++){
-			if(neurons[i]->getSynapse(j)->selectable(x,y)){
-				return neurons[i]->getSynapse(j);			
-			}
-		}
-	}
-	return nullptr;
-}
-/*
- * This function return a neuron based on its index
- */
-Neuron* Network::getNeuron(int index) const{
-	if((index>=0) and (index<(int)neurons.size()))
-		return neurons[index].get();
-	return nullptr;
+// ── State / draw ──────────────────────────────────────────────────────────────
+
+void Network::deselectAll() {
+    for (const auto& n : neurons) {
+        n->setSelected(false);
+        for (int j = 0; j < n->getNb_neighbors(); ++j)
+            n->getSynapse(j)->setSelected(false);
+    }
 }
 
-/*
- * The neuron is added to the network and indexed by its creation date
- */
-void Network::addNeuron(Neuron* neuron){
-	neuron->setIndex((int)neurons.size());
-	neurons.push_back(std::unique_ptr<Neuron>(neuron));
+int Network::getState(bool* states) const {
+    int i = 0;
+    for (const auto& n : neurons) states[i++] = n->getState();
+    return i;
 }
 
-/*
- * Routine for suppression of a neuron from the network
- */
-void Network::delNeuron(int index){
-	if(getNeuron(index) == nullptr) return;
-
-	// Delete all synapses pointing to this neuron
-	for(int i = 0; i<(int)neurons.size(); i++){
-		if(getNeuron(i)->getSynapseByNeighborIndex(index) < getNeuron(i)->getNb_neighbors()){
-			getNeuron(i)->delSynapseBySynapseIndex(getNeuron(i)->getSynapseByNeighborIndex(index));
-			i--;
-		}
-	}
-
-	// Decrement indices of neurons after the deleted one
-	for(int i = index+1; i<(int)neurons.size(); i++){
-		getNeuron(i)->setIndex(i-1);
-	}
-
-	// Erase from vector (unique_ptr destructor frees the Neuron)
-	neurons.erase(neurons.begin() + index);
-}
-
-/*
- * Get the states of all the neurons of the network
- * and return their number
- */
-int Network::getState(bool* states) const{
-	int i = 0;
-	for (const auto& n : neurons) states[i++] = n->getState();
-	return i;
-}
-
-
-/*
- * Draw the synapses then the neurons
- */
-void Network::drawMe(QPainter* painter, float scale, int transX, int transY){
-	for (const auto& n : neurons) n->drawSynapses(painter, scale, transX, transY);
-	for (const auto& n : neurons) n->drawMe(painter, scale, transX, transY);
+void Network::drawMe(QPainter* painter, float scale, int transX, int transY) {
+    for (const auto& n : neurons) n->drawSynapses(painter, scale, transX, transY);
+    for (const auto& n : neurons) n->drawMe(painter, scale, transX, transY);
 }

--- a/Neuron.cpp
+++ b/Neuron.cpp
@@ -1,8 +1,11 @@
 #include "NeuronSynapse.h"
 #include <cmath>
+#include <algorithm>
 #include "constFile.h"
 #include <iostream>
 #include "random-singleton.h"
+#include <QtGui/QRadialGradient>
+#include <QtGui/QFont>
 
 
 using namespace std;
@@ -514,23 +517,64 @@ int Neuron::getSynapseByNeighborIndex(int neighborIndex) const{
  * Draw the neuron.
  */
 void Neuron::drawMe(QPainter* painter, double scale, double transX, double transY){
-	// Draw The Neuron
-			painter->setRenderHint(QPainter::Antialiasing, true);
-			if(yellowMe)
-				painter->setPen(QPen(Qt::yellow, 3*scale, Qt::SolidLine, Qt::RoundCap));
-			else if(!selected)
-				painter->setPen(QPen(Qt::black, 3*scale, Qt::SolidLine, Qt::RoundCap));
-			else
-				painter->setPen(QPen(Qt::blue, 3*scale, Qt::SolidLine, Qt::RoundCap));
+    painter->setRenderHint(QPainter::Antialiasing, true);
+    painter->setRenderHint(QPainter::TextAntialiasing, true);
 
-			if(state > 1)
-				painter->setBrush(QBrush(Qt::darkGreen, Qt::SolidPattern));
-			else if(state == 1)
-				painter->setBrush(QBrush(Qt::green, Qt::SolidPattern));
-			else
-				painter->setBrush(QBrush(Qt::red, Qt::SolidPattern));
+    const double cx = x * scale + transX;
+    const double cy = y * scale + transY;
+    const double r  = 13.0 * scale;
+    const QRectF rect(cx - r, cy - r, 2 * r, 2 * r);
 
-			painter->drawEllipse(QRectF((x-10)*scale + transX, (y-10)*scale + transY, 20*scale, 20*scale));
+    // --- fill color by state (dark theme palette) ---
+    QColor baseColor;
+    if (state > 1)       baseColor = QColor(0xa6, 0xe3, 0xa1); // green
+    else if (state == 1) baseColor = QColor(0x89, 0xb4, 0xfa); // blue
+    else                 baseColor = QColor(0xf3, 0x8b, 0xa8); // red/inactive
+
+    // radial gradient: lighter centre, darker edge
+    QRadialGradient grad(cx - r * 0.3, cy - r * 0.3, r * 1.3);
+    grad.setColorAt(0.0, baseColor.lighter(130));
+    grad.setColorAt(1.0, baseColor.darker(150));
+
+    // drop shadow
+    painter->setPen(Qt::NoPen);
+    painter->setBrush(QColor(0, 0, 0, 60));
+    painter->drawEllipse(rect.translated(2 * scale, 3 * scale));
+
+    // body
+    painter->setBrush(grad);
+
+    if (yellowMe) {
+        // block-mode highlight: yellow glow ring
+        painter->setPen(QPen(QColor(0xf9, 0xe2, 0xaf), 3.0 * scale, Qt::SolidLine, Qt::RoundCap));
+    } else if (selected) {
+        // selection: accent glow
+        painter->setPen(QPen(QColor(0xcb, 0xa6, 0xf7), 3.0 * scale, Qt::SolidLine, Qt::RoundCap));
+    } else {
+        painter->setPen(QPen(QColor(0x31, 0x32, 0x44), 1.5 * scale, Qt::SolidLine, Qt::RoundCap));
+    }
+
+    painter->drawEllipse(rect);
+
+    // state label inside the neuron
+    painter->setPen(QColor(0x1e, 0x1e, 0x2e));
+    QFont f = painter->font();
+    f.setPixelSize(std::max(8, static_cast<int>(10 * scale)));
+    f.setBold(true);
+    painter->setFont(f);
+    painter->drawText(rect, Qt::AlignCenter, QString::number(state));
+
+    // nodeID label below the neuron
+    if (!nodeID.empty()) {
+        painter->setPen(QColor(0xa6, 0xad, 0xc8));
+        QFont lf = painter->font();
+        lf.setBold(false);
+        lf.setPixelSize(std::max(7, static_cast<int>(9 * scale)));
+        painter->setFont(lf);
+        QRectF labelRect(cx - 30 * scale, cy + r + 2 * scale, 60 * scale, 14 * scale);
+        painter->drawText(labelRect, Qt::AlignCenter,
+                          QString::fromStdString(nodeID));
+    }
 }
 
 /*

--- a/SPECS.md
+++ b/SPECS.md
@@ -1,0 +1,611 @@
+# NetworkDesigner — Functional Specification
+
+> **Purpose:** Rétro-documentation iso-fonctionnelle, base de référence pour la modernisation de la stack technique.  
+> **Audience:** Développeurs, contributeurs, recetteurs de la migration.
+
+---
+
+## 1. Vue d'ensemble
+
+**NetworkDesigner** est une application desktop Qt (C++) pour la conception, la simulation et l'analyse de réseaux de neurones à états discrets. Elle repose sur des dynamiques de type machine de Boltzmann.
+
+### Fonctionnalités principales
+
+| Domaine | Fonctionnalité |
+|---|---|
+| Conception | Création visuelle de neurones et synapses par glisser-déposer |
+| Paramétrage | Poids, délais, seuils, température, nombre d'états par neurone |
+| Planification | Schémas de mise à jour : Parallèle, Séquentiel, Blocs |
+| Simulation | Attracteurs, bassins d'attraction, activité, diffusion |
+| Persistance | Chargement/sauvegarde au format XML `.nml` |
+| Export | Format Prolog GNBox Premodel |
+
+### Architecture générale
+
+```
+┌─────────────────────────────────────────────────────────────┐
+│                        Qt Main Window                        │
+│  ┌─────────────┐  ┌──────────────────┐  ┌───────────────┐  │
+│  │  DesignPlan │  │ EvenementHandler │  │  Panels (UI)  │  │
+│  │  (Canvas)   │  │ (Slots/Signals)  │  │  Spinboxes… │  │
+│  └──────┬──────┘  └────────┬─────────┘  └───────────────┘  │
+│         │                  │                                  │
+│  ┌──────▼──────────────────▼────────────┐                   │
+│  │              Network Model            │                   │
+│  │  Network → [Neuron → [Synapse]]       │                   │
+│  │  UpdateSchedulingPlan → [UpdateBlock] │                   │
+│  └──────────────────┬────────────────────┘                   │
+│                     │                                         │
+│  ┌──────────────────▼────────────────────┐                   │
+│  │              Computer                  │                   │
+│  │  computeP / computeS / computeBS / BP │                   │
+│  └──────────────────┬────────────────────┘                   │
+│                     │                                         │
+│  ┌──────────────────▼────────────────────┐                   │
+│  │           Simulations                  │                   │
+│  │  Attractors  Activity  Diffusion       │                   │
+│  └────────────────────────────────────────┘                   │
+└─────────────────────────────────────────────────────────────┘
+```
+
+Séparation **Modèle / Vue** via le système de signaux/slots Qt.
+
+---
+
+## 2. Modèle de données
+
+### 2.1 Network
+
+Conteneur racine de tous les neurones.
+
+| Attribut | Type | Description |
+|---|---|---|
+| `neurons` | `vector<unique_ptr<Neuron>>` | Liste ordonnée (index = position) |
+| `temperature` | `double` | Température globale du réseau |
+| `uniformalTemperature` | `bool` | `true` → tous les neurones utilisent la température réseau |
+
+**Méthodes clés :**
+- `addNeuron(Neuron*)` — ajoute et auto-indexe
+- `delNeuron(int index)` — supprime et met à jour toutes les références
+- `getNeuron(int x, int y, int radius)` — recherche spatiale (événements souris)
+- `getSynapse(int x, int y)` — hit-testing synapse
+- `getState(bool*)` — export de l'état complet du réseau
+- `drawMe(QPainter*, scale, transX, transY)` — rendu : synapses puis neurones
+
+### 2.2 Neuron
+
+Unité computationnelle avec dynamique multi-états.
+
+| Attribut | Type | Description |
+|---|---|---|
+| `index` | `int` | Identifiant unique dans le réseau |
+| `state` | `int` | État courant : `0` à `nbStates-1` |
+| `nbStates` | `int` | Nombre d'états possibles (défaut : 2) |
+| `threshold` | `vector<double>` | `threshold[i]` = seuil pour atteindre l'état `i+1` |
+| `temperature` | `double` | Température individuelle (si non uniforme) |
+| `nodeID` | `string` | Identifiant utilisateur pour les exports |
+| `synapses` | `vector<unique_ptr<Synapse>>` | Synapses entrantes |
+| `hasANewState` | `bool` | Flag : un nouvel état a été calculé |
+| `theNewState` | `int` | Prochain état (en attente de `substitute()`) |
+| `x, y` | `double` | Position sur le canvas |
+| `selected` | `bool` | Sélection UI |
+| `yellowMe` | `bool` | Appartenance au bloc de mise à jour courant |
+
+**Gestion des seuils :**
+- État 0 : seuil effectif = `-1000.0` (toujours atteignable)
+- État `i > 0` : `getThreshold(i)` retourne `threshold[i-1]`
+
+**Couleurs de rendu :**
+| État | Couleur de remplissage |
+|---|---|
+| 0 | Rouge |
+| 1 | Vert |
+| ≥ 2 | Vert foncé |
+
+Bordure : Bleu (sélectionné) / Jaune (bloc actif) / Noir (normal)
+
+### 2.3 Synapse
+
+Connexion dirigée entre deux neurones.
+
+| Attribut | Type | Description |
+|---|---|---|
+| `baseNeuron` | `Neuron*` | Neurone source |
+| `finalNeuron` | `Neuron*` | Neurone cible |
+| `weight` | `double` | Force de la connexion (peut être négatif) |
+| `delay` | `int` | Délai en pas de temps (0 = immédiat) |
+| `states` | `queue<int>` | File FIFO pour implémenter le délai |
+| `gExcentricity` | `float` | Décalage du point de contrôle de Bézier |
+| `cx, cy` | `double` | Coordonnées du point de contrôle |
+
+**Mécanisme de délai :**
+```
+getStateOfTheFinalNeuron():
+  states.push(finalNeuron->state)
+  if states.size() > delay:
+    return states.pop_front()   // état d'il y a 'delay' pas
+  else:
+    return 0                    // file pas encore remplie
+```
+
+**Rendu :**
+- Auto-synapse : ellipse autour du neurone source
+- Autre synapse : courbe de Bézier quadratique avec flèche
+- Couleur : Bleu (sélectionné) / Rouge (poids négatif) / Noir (positif)
+- Style : Continu (delay=0) / Pointillé (delay>0)
+
+**Formule Bézier :**
+```
+cx = (x1 + x2) * (0.5 + gExcentricity)
+cy = (y1 + y2) * (0.5 + gExcentricity)
+gExcentricity = +0.06 si baseIndex < finalIndex, sinon -0.06
+```
+
+### 2.4 UpdateSchedulingPlan & UpdateBlock
+
+**UpdateSchedulingPlan** : conteneur ordonné de blocs de mise à jour.
+
+**UpdateBlock** : groupe de neurones mis à jour ensemble selon une méthode.
+
+| Attribut | Type | Description |
+|---|---|---|
+| `neuronsIndexs` | `vector<int>` | Indices des neurones du groupe |
+| `UpdateMethods` | `int` | Méthode de mise à jour (constante ci-dessous) |
+
+**Méthodes de mise à jour (constFile.h) :**
+
+| Constante | Valeur | Comportement |
+|---|---|---|
+| `COMPUTE` | 0 | Calcul normal (Boltzmann) |
+| `FIXE` | 1 | Non utilisé |
+| `FIXE_1` | 2 | Forcer état 1 |
+| `FIXE_0` | 3 | Forcer état 0 |
+| `FIXE_01` | 4 | Alterner : 0, 1, 0, 1, … |
+| `FIXE_10` | 5 | Alterner : 1, 0, 1, 0, … |
+| `RANDOMLY` | 6 | État aléatoire à chaque pas |
+
+---
+
+## 3. Algorithmes de simulation
+
+### 3.1 Calcul d'état d'un neurone (Boltzmann)
+
+**Entrées :**
+- États courants des neurones voisins (avec délais appliqués)
+- Poids des synapses entrantes
+- Seuils du neurone
+- Température `T`
+
+#### Cas déterministe (T = 0)
+
+```
+pour chaque état i de 0 à nbStates-2 :
+  sum[i] = Σ(weight[j] * delayed_state[j]) - threshold[i]
+
+nouvel_état = 0
+pour i de 0 à nbStates-2 :
+  si sum[i] >= 0 ET (i == nbStates-2 OU sum[i+1] < 0) :
+    nouvel_état = i+1
+    arrêt
+```
+
+Le neurone monte jusqu'au plus haut état dont le seuil est franchi.
+
+#### Cas stochastique (T > 0)
+
+```
+boltzmannTerm[i] = 1 / (1 + exp(-sum[i-1] / T))
+
+Direction bias (conditions aux bords) :
+  état == 0          → prob_montée = 0.1
+  état == nbStates-1 → prob_montée = 0.9
+  sinon              → prob_montée = aléatoire(0,1)
+
+Probabilités de transition construites par produit de termes de Boltzmann.
+Sélection par roulette (tirage aléatoire sur la distribution).
+```
+
+**Propriétés :**
+- T=0 : déterministe, suit le paysage énergétique
+- T→∞ : uniforme aléatoire
+- Implémente une distribution de Boltzmann discrète
+
+### 3.2 Schémas de mise à jour (Computer)
+
+**Synchrony rate** : probabilité qu'un neurone calcule à chaque pas (défaut : 1.0).
+
+#### Parallèle (computeP)
+```
+pour chaque itération :
+  pour chaque neurone : si aléatoire() <= syncRate → compute()
+  pour chaque neurone : substitute()          // application simultanée
+  émettre tick()
+```
+Tous les neurones voient le même état précédent avant mise à jour.
+
+#### Séquentiel (computeS)
+```
+pour chaque itération :
+  pour chaque neurone :
+    si aléatoire() <= syncRate → compute() puis substitute()  // immédiat
+  émettre tick()
+```
+Chaque neurone voit les mises à jour des neurones précédents dans la séquence.
+
+#### Blocs Séquentiels (computeBS)
+```
+pour chaque itération :
+  pour chaque bloc dans UpdateSchedulingPlan :
+    si méthode == COMPUTE :
+      pour chaque neurone du bloc : compute()
+      pour chaque neurone du bloc : substitute()
+    sinon :
+      appliquer état fixe/aléatoire selon méthode
+  émettre tick()
+```
+Les blocs s'exécutent séquentiellement, les neurones au sein d'un bloc en parallèle.
+
+### 3.3 Analyse des attracteurs et bassins d'attraction
+
+**Objectif :** Partitionner l'espace d'états complet en attracteurs (cycles) et leurs bassins (états qui y convergent).
+
+**Complexité :** O(∏ nbStates[i]) — exponentielle en nombre de neurones. Limite pratique ≈ 10–15 neurones binaires.
+
+#### Algorithme principal
+
+```
+totalStates = ∏(nbStates[i])
+visités = 0
+
+tant que visités < totalStates :
+  état = état_non_visité_aléatoire()
+  si état déjà dans un bassin connu → marquer visité, continuer
+
+  trajectoire = []
+  courant = état
+
+  répéter jusqu'à max_iterations (2000) :
+    trajectoire.ajouter(courant)
+    suivant = calculer_suivant(courant)
+
+    si suivant dans trajectoire :
+      // Cycle détecté → attracteur
+      attracteur = trajectoire[index(suivant):]
+      bassin = exploration_arrière(attracteur)
+      stocker(attracteur, bassin)
+      visités += bassin.cardinalité()
+      arrêt
+
+    courant = suivant
+```
+
+#### Exploration arrière (BFS inverse)
+
+```
+exploration_arrière(attracteur) :
+  bassin = copie(attracteur)
+  file = copie(attracteur)
+
+  tant que file non vide :
+    état = file.défiler()
+    prédécesseurs = predecesseursDe(état)
+    pour pred dans prédécesseurs :
+      si pred pas dans bassin :
+        bassin.ajouter(pred)
+        file.enfiler(pred)
+
+  retourner bassin
+```
+
+#### Calcul des prédécesseurs
+
+```
+predecesseursDe(état_cible) :
+  résultat = ensemble_universel
+
+  pour chaque neurone_i :
+    solutions_i = résoudre(neurone_i, état_cible[i])
+    résultat = résultat ∩ solutions_i
+
+  retourner résultat
+
+résoudre(neurone_i, état_cible) :
+  // Énumère toutes les combinaisons d'états des voisins
+  // Simule compute() pour chaque combinaison
+  // Retourne les configurations menant à état_cible
+```
+
+### 3.4 États pseudo (représentation compressée)
+
+Pour compresser les ensembles d'états, `NetworkState` utilise des pseudo-états négatifs :
+
+| Valeur | Signification |
+|---|---|
+| `>= 0` | État discret exact |
+| `-1` | Incohérent (aucun état valide) |
+| `-n` (n>1) | Ensemble d'états : bit `i` mis = état `i` possible |
+
+**Exemples :**
+- `-3` = `0b11` = états {0, 1}
+- `-7` = `0b111` = états {0, 1, 2}
+- `-5` = `0b101` = états {0, 2}
+
+**Opérations :**
+```
+union(-a, -b)        = -(a | b)     // OR bit-à-bit
+intersection(-a, -b) = -(a & b)     // AND bit-à-bit (→ -1 si 0)
+différence(-a, -b)   = -(a & ~b)    // ET-NOT bit-à-bit
+```
+
+---
+
+## 4. Format de fichier NML
+
+Format XML propriétaire, extension `.nml`.
+
+### Structure générale
+
+```xml
+<?xml version="1.0"?>
+<Configuration>
+  <Network Temperature="…" UniformalTemperature="…" Nb_Neurons="…">
+    <Neuron Index="…" NodeID="…" State="…" NbStates="…"
+            Temperature="…" Nb_Neighbors="…" x="…" y="…">
+      <State Index="1" Threshold="…"/>
+      <!-- une balise State par état > 0 -->
+      <Synapse NeighborIndex="…" Weight="…" Delay="…" CX="…" CY="…"/>
+      <!-- une balise Synapse par connexion sortante -->
+    </Neuron>
+  </Network>
+  <UpdateSchedulingPlan Nb_UpdateBlocks="…">
+    <Block Size="…" Calculus="…">
+      <NeuronIndex Index="…"/>
+    </Block>
+  </UpdateSchedulingPlan>
+</Configuration>
+```
+
+### Attributs de référence
+
+**`<Network>`**
+
+| Attribut | Type | Description |
+|---|---|---|
+| `Temperature` | double | Température globale |
+| `UniformalTemperature` | 0/1 | 1 = température réseau pour tous |
+| `Nb_Neurons` | int | Nombre de neurones |
+
+**`<Neuron>`**
+
+| Attribut | Type | Description |
+|---|---|---|
+| `Index` | int | ID unique (ordre de création) |
+| `NodeID` | string | Label utilisateur (défaut : `"noname"`) |
+| `State` | int | État initial (0 à nbStates-1) |
+| `NbStates` | int | Nombre d'états (défaut : 2) |
+| `Temperature` | double | Température individuelle |
+| `Nb_Neighbors` | int | Nombre de synapses sortantes |
+| `x`, `y` | double | Position canvas |
+
+**`<State>` (seuil)**
+
+| Attribut | Type | Description |
+|---|---|---|
+| `Index` | int | Numéro d'état (1 à nbStates-1) |
+| `Threshold` | double | Seuil d'activation |
+
+Contrainte : exactement `NbStates - 1` éléments `<State>` par neurone.
+
+**`<Synapse>`**
+
+| Attribut | Type | Description |
+|---|---|---|
+| `NeighborIndex` | int | Index du neurone cible |
+| `Weight` | double | Poids (positif = excitateur, négatif = inhibiteur) |
+| `Delay` | int | Délai en pas de temps (≥ 0) |
+| `CX`, `CY` | double | Point de contrôle Bézier |
+
+Auto-synapse autorisée : `NeighborIndex == Index` du neurone parent.
+
+**`<Block>`**
+
+| Attribut | Type | Description |
+|---|---|---|
+| `Size` | int | Nombre de neurones dans le bloc |
+| `Calculus` | int | Méthode (voir constantes COMPUTE/FIXE_*/RANDOMLY) |
+
+### Exemple complet (2 neurones en boucle)
+
+```xml
+<?xml version="1.0"?>
+<Configuration>
+  <Network Temperature="0" UniformalTemperature="1" Nb_Neurons="2">
+    <Neuron Index="0" NodeID="A" State="1" NbStates="2"
+            Temperature="1" Nb_Neighbors="1" x="100" y="100">
+      <State Index="1" Threshold="0.5"/>
+      <Synapse NeighborIndex="1" Weight="1" Delay="0" CX="150" CY="100"/>
+    </Neuron>
+    <Neuron Index="1" NodeID="B" State="0" NbStates="2"
+            Temperature="1" Nb_Neighbors="1" x="200" y="100">
+      <State Index="1" Threshold="0.5"/>
+      <Synapse NeighborIndex="0" Weight="1" Delay="1" CX="150" CY="100"/>
+    </Neuron>
+  </Network>
+  <UpdateSchedulingPlan Nb_UpdateBlocks="1">
+    <Block Size="2" Calculus="0">
+      <NeuronIndex Index="0"/>
+      <NeuronIndex Index="1"/>
+    </Block>
+  </UpdateSchedulingPlan>
+</Configuration>
+```
+
+---
+
+## 5. Interactions UI (DesignPlan)
+
+### 5.1 Événements souris
+
+| Bouton | Modificateur | Zone | Action |
+|---|---|---|---|
+| Gauche | Aucun | Zone vide | Créer un neurone |
+| Gauche | Aucun | Neurone | Sélectionner (désélectionne les autres) |
+| Gauche | Aucun | Drag neurone | Déplacer tous les neurones sélectionnés |
+| Gauche | Aucun | Synapse | Basculer sélection de la synapse |
+| Gauche | Ctrl | Neurone | Basculer dans la multi-sélection |
+| Gauche | Shift* | Neurone | Basculer appartenance au bloc courant |
+| Droit | Aucun | Neurone (appui) | Démarrer création de synapse |
+| Droit | Aucun | Neurone (relâche) | Finaliser la synapse |
+| Milieu | Aucun | Drag | Panoramique du canvas |
+| Molette | Aucun | Haut | Zoom + (scale += 0.05, max 2.0) |
+| Molette | Aucun | Bas | Zoom – (scale -= 0.05, min 0.0) |
+
+*Shift uniquement si `currentUpdateBlock >= 0` (mode bloc actif)
+
+### 5.2 Clavier
+
+| Touche | Action |
+|---|---|
+| `Suppr` | Supprimer tous les neurones et synapses sélectionnés |
+
+### 5.3 Signaux émis par DesignPlan
+
+| Signal | Déclencheur |
+|---|---|
+| `neuronSelectedChanged(Neuron*)` | Sélection d'un neurone |
+| `synapseSelectedChanged(Synapse*)` | Sélection d'une synapse |
+| `blockModeInvoked(int)` | Ajout/retrait d'un neurone dans un bloc |
+| `networkIsModified()` | Toute modification structurelle |
+| `updateCalled()` | Mise à jour demandée |
+
+---
+
+## 6. Paramètres globaux et comportements
+
+### 6.1 Température
+
+| Valeur | Effet |
+|---|---|
+| `T = 0` | Déterministe : suit le paysage énergétique |
+| `T > 0` | Stochastique : transitions de Boltzmann |
+| `T → ∞` | Sélection d'état uniforme aléatoire |
+
+Peut être globale (réseau) ou locale (par neurone) selon `uniformalTemperature`.
+
+### 6.2 Taux de synchronie
+
+Probabilité (entre 0 et 1) qu'un neurone soit mis à jour à chaque pas.
+
+- `1.0` : entièrement synchrone (tous les neurones)
+- `0.5` : en moyenne la moitié des neurones par pas
+- `0.0` : réseau figé
+
+### 6.3 Valeurs par défaut à la création
+
+Chaque élément créé dans DesignPlan hérite des valeurs par défaut configurables :
+
+| Paramètre | Type | Portée |
+|---|---|---|
+| `defaultThreshold` | `vector<double>` | Par neurone créé |
+| `defaultNbStates` | `int` | Nombre d'états |
+| `defaultState` | `int` | État initial |
+| `defaultWeight` | `double` | Poids de synapse |
+| `defaultTemperature` | `double` | Température neurone |
+| `defaultDelay` | `int` | Délai synapse |
+
+---
+
+## 7. Export GNBox Premodel
+
+Génère un fichier Prolog pour l'outil GNBox.
+
+**Format :**
+```prolog
+premodel(Premodel) :-
+  Premodel = premodel(
+    [x_0, x_1, …, x_n],
+    [c(x_i, [i(x_0,1), i(x_1,1), …]), …],
+    [1, 1, …, 1]
+  ).
+```
+
+**Règles :**
+- Chaque neurone avec au moins une entrée : liste ses voisins entrants
+- Neurone sans entrée (Garden of Eden) : auto-interaction `i(x_i,1)`
+- Seuils : toujours `1` (simplifié pour GNBox)
+
+---
+
+## 8. Flux d'exécution typique
+
+```
+1. Démarrage
+   main() → QApplication + fenêtre principale
+   EvenementHandler connecte les widgets Qt
+
+2. Chargement réseau
+   DesignPlan.load(path) → NetworkDesignerParser.load()
+   → Parsing XML → Network + UpdateSchedulingPlan créés
+   → Rendu canvas
+
+3. Conception interactive
+   Événements souris/clavier → DesignPlan
+   → Signaux → EvenementHandler → mise à jour panneaux UI
+
+4. Paramétrage
+   Spinboxes/comboboxes → slots EvenementHandler
+   → setters sur Network / Neuron / Synapse
+   → repaint DesignPlan
+
+5. Simulation
+   Bouton Start → Computer.compute*()
+   Pour chaque itération :
+     - Neurons compute next state
+     - substitute() (application)
+     - tick() signal émis
+     - Barre de progression mise à jour
+
+6. Arrêt
+   Bouton Stop → Computer.stopComputing() → stop=true
+
+7. Sauvegarde
+   DesignPlan.save(path) → NetworkDesignerParser.save()
+   → QDomDocument → fichier .nml
+```
+
+---
+
+## 9. Limitations connues
+
+| Limitation | Impact |
+|---|---|
+| Pas d'apprentissage (poids statiques) | Réseau figé à la conception |
+| Pas de plasticité synaptique | Pas de Hebbian ou STDP |
+| Temps discret uniquement | Pas de dynamiques continues |
+| Analyse attracteurs exponentielle | Limite pratique ≈ 10–15 neurones binaires |
+| Simulation couplée à Qt event loop | Difficile à paralléliser ou headless |
+| Graine aléatoire non contrôlable depuis l'UI | Non-reproductibilité |
+| Mémoire non bornée pour les bassins | Risque OOM sur grands réseaux |
+
+---
+
+## 10. Cas de test de non-régression
+
+Ces fichiers `.nml` inclus dans le projet servent de référence pour valider une migration :
+
+| Fichier | Description | Résultat attendu |
+|---|---|---|
+| `Arabidopsis.nml` | Réseau régulateur floral | Attracteurs biologiques connus |
+| `HeartBeat.nml` | Oscillateur cardiaque | Cycle périodique stable |
+| `EukarioteCell.nml` | Cycle cellulaire eucaryote | Attracteurs de phase G1/S/G2/M |
+
+**Protocole de validation :**
+1. Charger le fichier `.nml`
+2. Lancer simulation Parallèle, 100 itérations, T=0
+3. Capturer l'état final de chaque neurone
+4. Comparer avec la valeur de référence obtenue sur la version actuelle
+5. Lancer analyse attracteurs — comparer le nombre et les états des attracteurs
+
+---
+
+*Document généré par rétro-documentation du code source. Mise à jour requise si le comportement fonctionnel est modifié.*

--- a/Synapse.cpp
+++ b/Synapse.cpp
@@ -1,5 +1,7 @@
 #include "NeuronSynapse.h"
 #include <iostream>
+#include <cmath>
+#include <algorithm>
 using namespace std;
 
 Synapse::Synapse(){
@@ -84,69 +86,78 @@ void Synapse::setSelected(bool selected){
  * Build and draw the graphical representation (QPainterPath) of the arrow
  */
 void Synapse::drawMe(QPainter * painter, double scale, double transX, double transY){
-	
-	QPainterPath rectPath;
-	qreal pp;
-	qreal per;
-	QPointF startPoint, endPoint;
-	
-	double x1 = (baseNeuron->getX()*scale) + transX;
-	double y1 = (baseNeuron->getY()*scale) + transY;
-	
-	if(baseNeuron == finalNeuron){
-			rectPath.addEllipse(x1-19*scale, y1-19*scale, 17*scale, 18*scale);
-	} 
-	else {
-		// body building
-		double x2 = (finalNeuron->getX()*scale) + transX;
-		double y2 = (finalNeuron->getY()*scale) + transY;
-		//double cx = (x1 + x2) * (0.5f + gExcentricity);
-		//double cy = (y1 + y2) *(0.5f + gExcentricity);
-		double cx = (this->cx * scale) + transX;
-		double cy = (this->cy * scale) + transY;
-		
-		rectPath.moveTo(x1, y1);
-		rectPath.quadTo(cx, cy, x2, y2);
-		
-		// Arrow Head builing
-		//pp = rectPath.length()-25;
-		double headLength = 2;
-		double alpha;
-		
-		pp = 25;
-		per = rectPath.percentAtLength(pp);
-		startPoint = rectPath.pointAtPercent(per);
-		
-		//pp = rectPath.length()-20;
-		pp = 20;
-		per = rectPath.percentAtLength(pp);
-		endPoint = rectPath.pointAtPercent(per);
-		
-		alpha = atan((endPoint.y()-startPoint.y())/((endPoint.x()-startPoint.x())));
-		QPointF p1(startPoint.x()+headLength*sin(alpha), startPoint.y()-headLength*cos(alpha));
-		QPointF p2(startPoint.x()-headLength*sin(alpha), startPoint.y()+headLength*cos(alpha));
-		//QPointF p1(startPoint.x()+2*sin(alpha), startPoint.x()-2*cos(alpha));
-		
-		//cout << startPoint.x()<<endl;
-		rectPath.moveTo(p1);
-		rectPath.lineTo(endPoint);
-		rectPath.moveTo(p2);
-		rectPath.lineTo(endPoint);		
-	}	
-	// Updating
+    painter->setRenderHint(QPainter::Antialiasing, true);
+
+    QPainterPath rectPath;
+
+    double x1 = (baseNeuron->getX() * scale) + transX;
+    double y1 = (baseNeuron->getY() * scale) + transY;
+
+    if (baseNeuron == finalNeuron) {
+        // Self-synapse: small ellipse above the neuron
+        rectPath.addEllipse(x1 - 19 * scale, y1 - 24 * scale, 18 * scale, 18 * scale);
+    } else {
+        double x2 = (finalNeuron->getX() * scale) + transX;
+        double y2 = (finalNeuron->getY() * scale) + transY;
+        double bcx = (this->cx * scale) + transX;
+        double bcy = (this->cy * scale) + transY;
+
+        rectPath.moveTo(x1, y1);
+        rectPath.quadTo(bcx, bcy, x2, y2);
+
+        // Arrow head — proportional to scale, minimum 5 px
+        const double headLen = std::max(5.0, 7.0 * scale);
+        qreal pp, per;
+        QPointF tip, root;
+
+        pp  = headLen + 4;
+        per = rectPath.percentAtLength(pp);
+        root = rectPath.pointAtPercent(per);
+
+        pp  = headLen;
+        per = rectPath.percentAtLength(pp);
+        tip = rectPath.pointAtPercent(per);
+
+        double alpha = std::atan2(tip.y() - root.y(), tip.x() - root.x());
+        const double wing = headLen * 0.45;
+        QPointF p1(root.x() + wing * std::sin(alpha), root.y() - wing * std::cos(alpha));
+        QPointF p2(root.x() - wing * std::sin(alpha), root.y() + wing * std::cos(alpha));
+
+        rectPath.moveTo(p1);
+        rectPath.lineTo(tip);
+        rectPath.moveTo(p2);
+        rectPath.lineTo(tip);
+    }
+
     gPath = rectPath;
-    
-    if(baseNeuron->getSelected() and finalNeuron->getSelected()) selected = true;
-    
-    Qt::PenStyle myStyle;
-    
-    if(delay==0) myStyle = Qt::SolidLine;
-    else		 myStyle = Qt::DashLine;
-     
-    if(selected)  painter->setPen(QPen(Qt::blue, 2*scale, myStyle, Qt::RoundCap));
-    else if(weight >= 0) painter->setPen(QPen(Qt::black, 2*scale, myStyle, Qt::RoundCap));
-    else painter->setPen(QPen(Qt::red, 2*scale, myStyle, Qt::RoundCap));
-    painter->drawPath(gPath);	
+
+    if (baseNeuron->getSelected() && finalNeuron->getSelected())
+        selected = true;
+
+    // Color palette matching dark theme
+    QColor lineColor;
+    if (selected)        lineColor = QColor(0xcb, 0xa6, 0xf7); // purple accent
+    else if (weight >= 0) lineColor = QColor(0x89, 0xb4, 0xfa); // blue (excitatory)
+    else                  lineColor = QColor(0xf3, 0x8b, 0xa8); // red (inhibitory)
+
+    Qt::PenStyle myStyle = (delay == 0) ? Qt::SolidLine : Qt::DashLine;
+    double lineWidth = selected ? 2.5 * scale : 1.8 * scale;
+
+    painter->setPen(QPen(lineColor, lineWidth, myStyle, Qt::RoundCap, Qt::RoundJoin));
+    painter->setBrush(Qt::NoBrush);
+    painter->drawPath(gPath);
+
+    // Weight label near the midpoint of the path
+    if (gPath.length() > 20) {
+        QPointF mid = gPath.pointAtPercent(0.5);
+        painter->setPen(QColor(0xa6, 0xad, 0xc8));
+        QFont f = painter->font();
+        f.setPixelSize(std::max(7, static_cast<int>(8 * scale)));
+        painter->setFont(f);
+        painter->drawText(QRectF(mid.x() + 3, mid.y() - 8, 40, 14),
+                          Qt::AlignLeft | Qt::AlignVCenter,
+                          QString::number(weight, 'g', 3));
+    }
 }
 
 /*

--- a/UpdateBlock.cpp
+++ b/UpdateBlock.cpp
@@ -1,101 +1,37 @@
 #include "UpdateBlock.h"
-using namespace std;
+#include <algorithm>
 
-UpdateBlock::UpdateBlock()
-{
-	size = 0;
-	UpdateMethods = COMPUTE;
+UpdateBlock::UpdateBlock() : size(0), UpdateMethods(COMPUTE) {}
+UpdateBlock::~UpdateBlock() = default;
+
+UpdateBlock::UpdateBlock(const UpdateBlock& other)
+    : neuronsIndexs(other.neuronsIndexs)
+    , size(other.size)
+    , UpdateMethods(other.UpdateMethods)
+{}
+
+void UpdateBlock::addNeuronIndex(int index) {
+    auto it = std::find(neuronsIndexs.begin(), neuronsIndexs.end(), index);
+    if (it == neuronsIndexs.end()) {
+        neuronsIndexs.push_back(index);
+        ++size;
+    }
 }
 
-UpdateBlock::~UpdateBlock()
-{
-	neuronsIndexs.clear();
+void UpdateBlock::delNeuronIndex(int index) {
+    auto it = std::find(neuronsIndexs.begin(), neuronsIndexs.end(), index);
+    if (it != neuronsIndexs.end()) {
+        neuronsIndexs.erase(it);
+        --size;
+    }
 }
 
-UpdateBlock::UpdateBlock(const UpdateBlock& updateBlock){
-	size = 0;
-	UpdateMethods = COMPUTE;
-
-	this->UpdateMethods = updateBlock.getUpdateMethods();
-
-	for(int i=0; i<updateBlock.getSize();i++){
-		addNeuronIndex(updateBlock.getNeuronIndex(i));
-	}
+void UpdateBlock::decrementGreaterThan(int index) {
+    for (int& idx : neuronsIndexs)
+        if (idx > index) --idx;
 }
 
-
-/*
- * Add a neuron's index to the neuronIndexs
- */
-void UpdateBlock::addNeuronIndex(int index){
-	vector<int>::iterator vectIterator = neuronsIndexs.begin();
-	if(size!= 0){
-		while(vectIterator != neuronsIndexs.end()) {
-			if(*vectIterator != index){
-				vectIterator++;
-			}
-			else break;
-		}
-		if(vectIterator == neuronsIndexs.end()) {
-			neuronsIndexs.push_back(index);
-			size++;
-		}
-	}
-	else{
-		neuronsIndexs.push_back(index);
-		size++;
-	}
-}
-
-/*
- * Delete the neuron's index from the vector of the neuronIndexs
- */
-void UpdateBlock::delNeuronIndex(int index){
-	vector<int>::iterator vectIterator = neuronsIndexs.begin();
-	while(vectIterator != neuronsIndexs.end()){
-		if(*vectIterator != index)	vectIterator++;
-		else break;
-	}
-	if(vectIterator != neuronsIndexs.end()) {
-		neuronsIndexs.erase(vectIterator);
-		size--;
-	}
-}
-
-/*
- * Return the UpdateMethods
- */
-int UpdateBlock::getUpdateMethods() const{
-	return UpdateMethods;
-}
-
-/*
- *  Set the UpdateMethods
- */
-void UpdateBlock::setUpdateMethods(int UpdateMethods){
-	this->UpdateMethods = UpdateMethods;
-}
-
-/*
- * Return the index of the neuron at the ith place in the vector neuronsIndexs
- */
-int UpdateBlock::getNeuronIndex(int i) const{
-	return neuronsIndexs[i];
-}
-
-/*
- * Decrement the index of the neurons which their indexs is greater than i
- */
-void UpdateBlock::decrementGreaterThan(int index){
-	for(int i=0; i < size; i++){
-		if(neuronsIndexs[i]>index) neuronsIndexs[i]--;
-	}
-}
-
-/*
- * Return the size of the UpdateBlock
- */
-int UpdateBlock::getSize() const{
-	return size;
-}
-
+int  UpdateBlock::getUpdateMethods() const        { return UpdateMethods; }
+void UpdateBlock::setUpdateMethods(int m)          { UpdateMethods = m; }
+int  UpdateBlock::getNeuronIndex(int i) const      { return neuronsIndexs[i]; }
+int  UpdateBlock::getSize() const                  { return size; }

--- a/UpdateSchedulingPlan.cpp
+++ b/UpdateSchedulingPlan.cpp
@@ -1,56 +1,30 @@
 #include "UpdateSchedulingPlan.h"
-using namespace std;
+#include <algorithm>
 
-UpdateSchedulingPlan::UpdateSchedulingPlan()
-{
-	nb_blocks=0;
+UpdateSchedulingPlan::UpdateSchedulingPlan() : nb_blocks(0) {}
+
+UpdateSchedulingPlan::UpdateSchedulingPlan(const UpdateSchedulingPlan& other) : nb_blocks(0) {
+    for (int i = 0; i < other.getNb_blocks(); ++i)
+        addUpdateBlock(new UpdateBlock(*other.getUpdateBlock(i)));
 }
 
-UpdateSchedulingPlan::UpdateSchedulingPlan(const UpdateSchedulingPlan& updateSchedulingPlan){
-	nb_blocks = 0;
-	for(int i=0; i < updateSchedulingPlan.getNb_blocks(); i++){
-		addUpdateBlock(new UpdateBlock(*(updateSchedulingPlan.getUpdateBlock(i))));
-	}
+UpdateSchedulingPlan::~UpdateSchedulingPlan() {
+    for (UpdateBlock* ub : sequentialblocks) delete ub;
 }
 
-/*
- * Deleting all the element in the vector
- */
-UpdateSchedulingPlan::~UpdateSchedulingPlan()
-{
-	//if(sequentialblocks.size()>0)
-		//sequentialblocks.erase(sequentialblocks.begin(), sequentialblocks.begin()+nb_blocks);
+int UpdateSchedulingPlan::getNb_blocks() const { return nb_blocks; }
 
+void UpdateSchedulingPlan::addUpdateBlock(UpdateBlock* ub) {
+    sequentialblocks.push_back(ub);
+    ++nb_blocks;
 }
 
-/*
- * Return the number of blocks
- */
-int UpdateSchedulingPlan::getNb_blocks() const{
-	return nb_blocks;
+void UpdateSchedulingPlan::delUpdateBlock(int index) {
+    delete sequentialblocks[index];
+    sequentialblocks.erase(sequentialblocks.begin() + index);
+    --nb_blocks;
 }
 
-/*
- * Add a new block to the update plan
- */
-void UpdateSchedulingPlan::addUpdateBlock(UpdateBlock* ub){
-	sequentialblocks.push_back(ub);
-	nb_blocks++;
-}
-
-/*
- * Delete a block from the update plan
- */
-void UpdateSchedulingPlan::delUpdateBlock(int index){
-
-	sequentialblocks.erase((vector<UpdateBlock*>::iterator)&sequentialblocks[index]);
-	nb_blocks--;
-}
-
-
-/*
- * Return the UpdateBlock from its index
- */
-UpdateBlock* UpdateSchedulingPlan::getUpdateBlock(int index) const{
-	return sequentialblocks[index];
+UpdateBlock* UpdateSchedulingPlan::getUpdateBlock(int index) const {
+    return sequentialblocks[index];
 }

--- a/designplan.h
+++ b/designplan.h
@@ -46,12 +46,19 @@ public:
 
 	void setCurrentUpdateBlock(int currentUpdateBlock);
 
+	double getScale() const    { return scale; }
+	void   setScale(double s)  { scale = s; repaint(); }
+
+public slots:
+	void resetView() { scale = 1.0; transX = transY = 0; repaint(); }
+
 signals:
 	void neuronSelectedChanged(Neuron* neuron);
 	void synapseSelectedChanged(Synapse* synapse);
 	void blockModeInvoked(int index);
 	void updateCalled();
 	void networkIsModified();
+	void canvasMouseMoved(int worldX, int worldY);
 
 protected:
 

--- a/main.cpp
+++ b/main.cpp
@@ -1,13 +1,24 @@
 #include "networkdesigner.h"
 
-#include <QtGui>
 #include <QApplication>
+#include <QFile>
+#include <QFontDatabase>
 #include "Network.h"
 #include "UpdateSchedulingPlan.h"
 
 int main(int argc, char *argv[])
 {
     QApplication a(argc, argv);
+    a.setApplicationName("NetworkDesigner");
+    a.setApplicationVersion("1.0");
+    a.setOrganizationName("NetworkDesigner");
+
+    QFile styleFile(":/resources/style.qss");
+    if (styleFile.open(QFile::ReadOnly)) {
+        a.setStyleSheet(styleFile.readAll());
+        styleFile.close();
+    }
+
     NetworkDesigner w;
     w.show();
     a.connect(&a, SIGNAL(lastWindowClosed()), &a, SLOT(quit()));

--- a/mainWindow.ui
+++ b/mainWindow.ui
@@ -68,7 +68,9 @@
               </widget>
              </item>
              <item>
-              <widget class="QComboBox" name="cmbSimulationType"/>
+              <widget class="QComboBox" name="cmbSimulationType">
+               <property name="toolTip"><string>Choose the simulation algorithm to run</string></property>
+              </widget>
              </item>
             </layout>
            </item>
@@ -83,6 +85,7 @@
              </item>
              <item>
               <widget class="QDoubleSpinBox" name="dsbTemperature">
+               <property name="toolTip"><string>Global temperature (0 = deterministic, &gt;0 = stochastic Boltzmann)</string></property>
                <property name="accelerated">
                 <bool>true</bool>
                </property>
@@ -107,6 +110,7 @@
            </item>
            <item>
             <widget class="QCheckBox" name="chkUniformalTemperature">
+             <property name="toolTip"><string>When checked, all neurons use the global temperature</string></property>
              <property name="text">
               <string>Uniformal Temperature</string>
              </property>
@@ -126,6 +130,7 @@
              </item>
              <item>
               <widget class="QSpinBox" name="sbUpdatesNumber">
+               <property name="toolTip"><string>Number of update iterations per simulation run</string></property>
                <property name="accelerated">
                 <bool>true</bool>
                </property>
@@ -153,6 +158,7 @@
              </item>
              <item>
               <widget class="QDoubleSpinBox" name="dsbSynchronyRate">
+               <property name="toolTip"><string>Probability that each neuron updates per iteration (1.0 = always)</string></property>
                <property name="accelerated">
                 <bool>true</bool>
                </property>
@@ -404,6 +410,7 @@
              </item>
              <item>
               <widget class="QDoubleSpinBox" name="dsbWeight">
+               <property name="toolTip"><string>Synaptic weight: positive = excitatory, negative = inhibitory</string></property>
                <property name="accelerated">
                 <bool>true</bool>
                </property>
@@ -434,6 +441,7 @@
              </item>
              <item>
               <widget class="QSpinBox" name="sbDelay">
+               <property name="toolTip"><string>Synaptic delay in time steps (0 = immediate, dashed line if &gt; 0)</string></property>
                <property name="maximum">
                 <number>10000</number>
                </property>

--- a/mainWindow.ui
+++ b/mainWindow.ui
@@ -6,631 +6,564 @@
    <rect>
     <x>0</x>
     <y>0</y>
-    <width>782</width>
-    <height>569</height>
+    <width>960</width>
+    <height>640</height>
    </rect>
   </property>
   <property name="windowTitle">
-   <string>MainWindow</string>
+   <string>Network Designer</string>
   </property>
   <widget class="QWidget" name="centralwidget">
-   <widget class="QToolBox" name="toolBox">
-    <property name="geometry">
-     <rect>
-      <x>10</x>
-      <y>50</y>
-      <width>201</width>
-      <height>421</height>
-     </rect>
+   <layout class="QHBoxLayout" name="mainLayout">
+    <property name="spacing">
+     <number>0</number>
     </property>
-    <property name="currentIndex">
-     <number>1</number>
+    <property name="contentsMargins">
+     <number>0</number>
+     <number>0</number>
+     <number>0</number>
+     <number>0</number>
     </property>
-    <widget class="QWidget" name="pSimulationParam">
-     <property name="geometry">
-      <rect>
-       <x>0</x>
-       <y>0</y>
-       <width>201</width>
-       <height>293</height>
-      </rect>
-     </property>
-     <attribute name="label">
-      <string>Simulation</string>
-     </attribute>
-     <widget class="QLabel" name="lblTemperature">
-      <property name="geometry">
-       <rect>
-        <x>0</x>
-        <y>50</y>
-        <width>91</width>
-        <height>18</height>
-       </rect>
+    <item>
+     <widget class="QWidget" name="leftPanel">
+      <property name="minimumWidth">
+       <number>220</number>
       </property>
-      <property name="text">
-       <string>Temperature:</string>
+      <property name="maximumWidth">
+       <number>240</number>
+      </property>
+      <layout class="QVBoxLayout" name="leftPanelLayout">
+       <property name="spacing">
+        <number>0</number>
+       </property>
+       <property name="contentsMargins">
+        <number>0</number>
+        <number>0</number>
+        <number>0</number>
+        <number>0</number>
+       </property>
+       <item>
+        <widget class="QToolBox" name="toolBox">
+         <widget class="QWidget" name="pSimulationParam">
+          <attribute name="label">
+           <string>Simulation</string>
+          </attribute>
+          <layout class="QVBoxLayout" name="simLayout">
+           <property name="spacing">
+            <number>8</number>
+           </property>
+           <property name="contentsMargins">
+            <number>10</number>
+            <number>10</number>
+            <number>10</number>
+            <number>10</number>
+           </property>
+           <item>
+            <layout class="QHBoxLayout">
+             <item>
+              <widget class="QLabel" name="label_2">
+               <property name="text">
+                <string>Type:</string>
+               </property>
+              </widget>
+             </item>
+             <item>
+              <widget class="QComboBox" name="cmbSimulationType"/>
+             </item>
+            </layout>
+           </item>
+           <item>
+            <layout class="QHBoxLayout">
+             <item>
+              <widget class="QLabel" name="lblTemperature">
+               <property name="text">
+                <string>Temperature:</string>
+               </property>
+              </widget>
+             </item>
+             <item>
+              <widget class="QDoubleSpinBox" name="dsbTemperature">
+               <property name="accelerated">
+                <bool>true</bool>
+               </property>
+               <property name="decimals">
+                <number>10</number>
+               </property>
+               <property name="minimum">
+                <double>0.000000000000000</double>
+               </property>
+               <property name="maximum">
+                <double>10000000000.000000000000000</double>
+               </property>
+               <property name="singleStep">
+                <double>0.001000000000000</double>
+               </property>
+               <property name="value">
+                <double>0.000000000000000</double>
+               </property>
+              </widget>
+             </item>
+            </layout>
+           </item>
+           <item>
+            <widget class="QCheckBox" name="chkUniformalTemperature">
+             <property name="text">
+              <string>Uniformal Temperature</string>
+             </property>
+             <property name="checked">
+              <bool>true</bool>
+             </property>
+            </widget>
+           </item>
+           <item>
+            <layout class="QHBoxLayout">
+             <item>
+              <widget class="QLabel" name="lblUpdatesNumber">
+               <property name="text">
+                <string>Iterations:</string>
+               </property>
+              </widget>
+             </item>
+             <item>
+              <widget class="QSpinBox" name="sbUpdatesNumber">
+               <property name="accelerated">
+                <bool>true</bool>
+               </property>
+               <property name="minimum">
+                <number>1</number>
+               </property>
+               <property name="maximum">
+                <number>100000</number>
+               </property>
+               <property name="value">
+                <number>100</number>
+               </property>
+              </widget>
+             </item>
+            </layout>
+           </item>
+           <item>
+            <layout class="QHBoxLayout">
+             <item>
+              <widget class="QLabel" name="lblSynchronyRate">
+               <property name="text">
+                <string>Synchrony rate:</string>
+               </property>
+              </widget>
+             </item>
+             <item>
+              <widget class="QDoubleSpinBox" name="dsbSynchronyRate">
+               <property name="accelerated">
+                <bool>true</bool>
+               </property>
+               <property name="decimals">
+                <number>3</number>
+               </property>
+               <property name="maximum">
+                <double>1.000000000000000</double>
+               </property>
+               <property name="singleStep">
+                <double>0.001000000000000</double>
+               </property>
+               <property name="value">
+                <double>1.000000000000000</double>
+               </property>
+              </widget>
+             </item>
+            </layout>
+           </item>
+           <item>
+            <layout class="QHBoxLayout">
+             <item>
+              <widget class="QLabel" name="lblSpeedPercent">
+               <property name="text">
+                <string>Speed (%):</string>
+               </property>
+              </widget>
+             </item>
+             <item>
+              <widget class="QSpinBox" name="sbSpeedPercent">
+               <property name="maximum">
+                <number>100</number>
+               </property>
+               <property name="value">
+                <number>100</number>
+               </property>
+              </widget>
+             </item>
+            </layout>
+           </item>
+           <item>
+            <layout class="QHBoxLayout">
+             <item>
+              <widget class="QPushButton" name="pbStart">
+               <property name="text">
+                <string>Start</string>
+               </property>
+              </widget>
+             </item>
+             <item>
+              <widget class="QPushButton" name="pbStop">
+               <property name="text">
+                <string>Stop</string>
+               </property>
+              </widget>
+             </item>
+            </layout>
+           </item>
+           <item>
+            <widget class="QProgressBar" name="progressBar">
+             <property name="value">
+              <number>0</number>
+             </property>
+            </widget>
+           </item>
+           <item>
+            <spacer>
+             <property name="orientation">
+              <enum>Qt::Vertical</enum>
+             </property>
+             <property name="sizeHint" stdset="0">
+              <size>
+               <width>20</width>
+               <height>40</height>
+              </size>
+             </property>
+            </spacer>
+           </item>
+          </layout>
+         </widget>
+         <widget class="QWidget" name="pNeuronsParam">
+          <attribute name="label">
+           <string>Neuron</string>
+          </attribute>
+          <layout class="QVBoxLayout" name="neuronLayout">
+           <property name="spacing">
+            <number>8</number>
+           </property>
+           <property name="contentsMargins">
+            <number>10</number>
+            <number>10</number>
+            <number>10</number>
+            <number>10</number>
+           </property>
+           <item>
+            <layout class="QHBoxLayout">
+             <item>
+              <widget class="QLabel" name="lblCurrent">
+               <property name="text">
+                <string>Index:</string>
+               </property>
+              </widget>
+             </item>
+             <item>
+              <widget class="QLineEdit" name="txtIndex"/>
+             </item>
+            </layout>
+           </item>
+           <item>
+            <layout class="QHBoxLayout">
+             <item>
+              <widget class="QLabel" name="lblLabel">
+               <property name="text">
+                <string>Node ID:</string>
+               </property>
+              </widget>
+             </item>
+             <item>
+              <widget class="QLineEdit" name="txtNodeID"/>
+             </item>
+            </layout>
+           </item>
+           <item>
+            <layout class="QHBoxLayout">
+             <item>
+              <widget class="QLabel" name="lblNeuronTemperature">
+               <property name="text">
+                <string>Temperature:</string>
+               </property>
+              </widget>
+             </item>
+             <item>
+              <widget class="QDoubleSpinBox" name="dsbNeuronTemperature">
+               <property name="decimals">
+                <number>10</number>
+               </property>
+               <property name="maximum">
+                <double>10000000000.000000000000000</double>
+               </property>
+               <property name="singleStep">
+                <double>0.001000000000000</double>
+               </property>
+              </widget>
+             </item>
+            </layout>
+           </item>
+           <item>
+            <layout class="QHBoxLayout">
+             <item>
+              <widget class="QLabel" name="lblStateNumber">
+               <property name="text">
+                <string>Nb states:</string>
+               </property>
+              </widget>
+             </item>
+             <item>
+              <widget class="QSpinBox" name="sbNbStates">
+               <property name="minimum">
+                <number>2</number>
+               </property>
+               <property name="value">
+                <number>2</number>
+               </property>
+              </widget>
+             </item>
+            </layout>
+           </item>
+           <item>
+            <layout class="QHBoxLayout">
+             <item>
+              <widget class="QLabel" name="lblState">
+               <property name="text">
+                <string>State:</string>
+               </property>
+              </widget>
+             </item>
+             <item>
+              <widget class="QComboBox" name="cmbState"/>
+             </item>
+            </layout>
+           </item>
+           <item>
+            <layout class="QHBoxLayout">
+             <item>
+              <widget class="QLabel" name="lblThreshold">
+               <property name="text">
+                <string>Threshold:</string>
+               </property>
+              </widget>
+             </item>
+             <item>
+              <widget class="QDoubleSpinBox" name="dsbThreshold">
+               <property name="accelerated">
+                <bool>true</bool>
+               </property>
+               <property name="decimals">
+                <number>10</number>
+               </property>
+               <property name="minimum">
+                <double>-99.989999999999995</double>
+               </property>
+               <property name="singleStep">
+                <double>0.001000000000000</double>
+               </property>
+               <property name="value">
+                <double>0.001000000000000</double>
+               </property>
+              </widget>
+             </item>
+            </layout>
+           </item>
+           <item>
+            <spacer>
+             <property name="orientation">
+              <enum>Qt::Vertical</enum>
+             </property>
+             <property name="sizeHint" stdset="0">
+              <size>
+               <width>20</width>
+               <height>40</height>
+              </size>
+             </property>
+            </spacer>
+           </item>
+          </layout>
+         </widget>
+         <widget class="QWidget" name="pSynapsesParam">
+          <attribute name="label">
+           <string>Synapse</string>
+          </attribute>
+          <layout class="QVBoxLayout" name="synapseLayout">
+           <property name="spacing">
+            <number>8</number>
+           </property>
+           <property name="contentsMargins">
+            <number>10</number>
+            <number>10</number>
+            <number>10</number>
+            <number>10</number>
+           </property>
+           <item>
+            <layout class="QHBoxLayout">
+             <item>
+              <widget class="QLabel" name="lblWeight">
+               <property name="text">
+                <string>Weight:</string>
+               </property>
+              </widget>
+             </item>
+             <item>
+              <widget class="QDoubleSpinBox" name="dsbWeight">
+               <property name="accelerated">
+                <bool>true</bool>
+               </property>
+               <property name="decimals">
+                <number>3</number>
+               </property>
+               <property name="minimum">
+                <double>-99.989999999999995</double>
+               </property>
+               <property name="singleStep">
+                <double>0.001000000000000</double>
+               </property>
+               <property name="value">
+                <double>1.000000000000000</double>
+               </property>
+              </widget>
+             </item>
+            </layout>
+           </item>
+           <item>
+            <layout class="QHBoxLayout">
+             <item>
+              <widget class="QLabel" name="lblDelay">
+               <property name="text">
+                <string>Delay:</string>
+               </property>
+              </widget>
+             </item>
+             <item>
+              <widget class="QSpinBox" name="sbDelay">
+               <property name="maximum">
+                <number>10000</number>
+               </property>
+              </widget>
+             </item>
+            </layout>
+           </item>
+           <item>
+            <spacer>
+             <property name="orientation">
+              <enum>Qt::Vertical</enum>
+             </property>
+             <property name="sizeHint" stdset="0">
+              <size>
+               <width>20</width>
+               <height>40</height>
+              </size>
+             </property>
+            </spacer>
+           </item>
+          </layout>
+         </widget>
+         <widget class="QWidget" name="pUpdateSchedule">
+          <attribute name="label">
+           <string>Schedule</string>
+          </attribute>
+          <layout class="QVBoxLayout" name="scheduleLayout">
+           <property name="spacing">
+            <number>8</number>
+           </property>
+           <property name="contentsMargins">
+            <number>10</number>
+            <number>10</number>
+            <number>10</number>
+            <number>10</number>
+           </property>
+           <item>
+            <layout class="QHBoxLayout">
+             <item>
+              <widget class="QLabel" name="lblScheduleType">
+               <property name="text">
+                <string>Type:</string>
+               </property>
+              </widget>
+             </item>
+             <item>
+              <widget class="QComboBox" name="cmbScheduleType"/>
+             </item>
+            </layout>
+           </item>
+           <item>
+            <layout class="QHBoxLayout">
+             <item>
+              <widget class="QLabel" name="lblUpdateBlock">
+               <property name="text">
+                <string>Block:</string>
+               </property>
+              </widget>
+             </item>
+             <item>
+              <widget class="QComboBox" name="cmbUpdateBlock"/>
+             </item>
+            </layout>
+           </item>
+           <item>
+            <layout class="QHBoxLayout">
+             <item>
+              <widget class="QLabel" name="lblUpdateMethods">
+               <property name="text">
+                <string>Method:</string>
+               </property>
+              </widget>
+             </item>
+             <item>
+              <widget class="QComboBox" name="cmbUpdateMethods"/>
+             </item>
+            </layout>
+           </item>
+           <item>
+            <spacer>
+             <property name="orientation">
+              <enum>Qt::Vertical</enum>
+             </property>
+             <property name="sizeHint" stdset="0">
+              <size>
+               <width>20</width>
+               <height>40</height>
+              </size>
+             </property>
+            </spacer>
+           </item>
+          </layout>
+         </widget>
+        </widget>
+       </item>
+      </layout>
+     </widget>
+    </item>
+    <item>
+     <widget class="QFrame" name="separator">
+      <property name="frameShape">
+       <enum>QFrame::VLine</enum>
+      </property>
+      <property name="frameShadow">
+       <enum>QFrame::Sunken</enum>
       </property>
      </widget>
-     <widget class="QDoubleSpinBox" name="dsbTemperature">
-      <property name="geometry">
-       <rect>
-        <x>100</x>
-        <y>50</y>
-        <width>71</width>
-        <height>27</height>
-       </rect>
-      </property>
-      <property name="accelerated">
+    </item>
+    <item>
+     <widget class="DesignPlan" name="frmDesign" native="true">
+      <property name="mouseTracking">
        <bool>true</bool>
       </property>
-      <property name="prefix">
-       <string/>
-      </property>
-      <property name="decimals">
-       <number>10</number>
-      </property>
-      <property name="minimum">
-       <double>0.000000000000000</double>
-      </property>
-      <property name="maximum">
-       <double>10000000000.000000000000000</double>
-      </property>
-      <property name="singleStep">
-       <double>0.001000000000000</double>
-      </property>
-      <property name="value">
-       <double>0.000000000000000</double>
+      <property name="sizePolicy">
+       <sizepolicy hsizetype="Expanding" vsizetype="Expanding">
+        <horstretch>1</horstretch>
+        <verstretch>1</verstretch>
+       </sizepolicy>
       </property>
      </widget>
-     <widget class="QSpinBox" name="sbUpdatesNumber">
-      <property name="geometry">
-       <rect>
-        <x>100</x>
-        <y>110</y>
-        <width>71</width>
-        <height>27</height>
-       </rect>
-      </property>
-      <property name="accelerated">
-       <bool>true</bool>
-      </property>
-      <property name="minimum">
-       <number>1</number>
-      </property>
-      <property name="maximum">
-       <number>100000</number>
-      </property>
-      <property name="value">
-       <number>100</number>
-      </property>
-     </widget>
-     <widget class="QLabel" name="lblUpdatesNumber">
-      <property name="geometry">
-       <rect>
-        <x>0</x>
-        <y>110</y>
-        <width>111</width>
-        <height>18</height>
-       </rect>
-      </property>
-      <property name="text">
-       <string>Updates number:</string>
-      </property>
-     </widget>
-     <widget class="QDoubleSpinBox" name="dsbSynchronyRate">
-      <property name="geometry">
-       <rect>
-        <x>100</x>
-        <y>150</y>
-        <width>71</width>
-        <height>27</height>
-       </rect>
-      </property>
-      <property name="accelerated">
-       <bool>true</bool>
-      </property>
-      <property name="decimals">
-       <number>3</number>
-      </property>
-      <property name="maximum">
-       <double>1.000000000000000</double>
-      </property>
-      <property name="singleStep">
-       <double>0.001000000000000</double>
-      </property>
-      <property name="value">
-       <double>1.000000000000000</double>
-      </property>
-     </widget>
-     <widget class="QLabel" name="lblSynchronyRate">
-      <property name="geometry">
-       <rect>
-        <x>0</x>
-        <y>150</y>
-        <width>101</width>
-        <height>18</height>
-       </rect>
-      </property>
-      <property name="text">
-       <string>Synchrony rate:</string>
-      </property>
-     </widget>
-     <widget class="QComboBox" name="cmbSimulationType">
-      <property name="geometry">
-       <rect>
-        <x>100</x>
-        <y>10</y>
-        <width>71</width>
-        <height>26</height>
-       </rect>
-      </property>
-     </widget>
-     <widget class="QLabel" name="label_2">
-      <property name="geometry">
-       <rect>
-        <x>0</x>
-        <y>10</y>
-        <width>101</width>
-        <height>18</height>
-       </rect>
-      </property>
-      <property name="text">
-       <string>Simulation type:</string>
-      </property>
-     </widget>
-     <widget class="QPushButton" name="pbStart">
-      <property name="geometry">
-       <rect>
-        <x>0</x>
-        <y>230</y>
-        <width>80</width>
-        <height>27</height>
-       </rect>
-      </property>
-      <property name="text">
-       <string>&amp;Start</string>
-      </property>
-     </widget>
-     <widget class="QPushButton" name="pbStop">
-      <property name="geometry">
-       <rect>
-        <x>100</x>
-        <y>230</y>
-        <width>80</width>
-        <height>27</height>
-       </rect>
-      </property>
-      <property name="text">
-       <string>St&amp;op</string>
-      </property>
-     </widget>
-     <widget class="QCheckBox" name="chkUniformalTemperature">
-      <property name="geometry">
-       <rect>
-        <x>-10</x>
-        <y>80</y>
-        <width>141</width>
-        <height>23</height>
-       </rect>
-      </property>
-      <property name="layoutDirection">
-       <enum>Qt::RightToLeft</enum>
-      </property>
-      <property name="text">
-       <string>Uniformal Temperature</string>
-      </property>
-      <property name="checked">
-       <bool>true</bool>
-      </property>
-     </widget>
-     <widget class="QLabel" name="lblSpeedPercent">
-      <property name="geometry">
-       <rect>
-        <x>0</x>
-        <y>190</y>
-        <width>71</width>
-        <height>18</height>
-       </rect>
-      </property>
-      <property name="text">
-       <string>SpeedPercent</string>
-      </property>
-     </widget>
-     <widget class="QSpinBox" name="sbSpeedPercent">
-      <property name="geometry">
-       <rect>
-        <x>100</x>
-        <y>190</y>
-        <width>71</width>
-        <height>27</height>
-       </rect>
-      </property>
-      <property name="maximum">
-       <number>100</number>
-      </property>
-      <property name="value">
-       <number>100</number>
-      </property>
-     </widget>
-     <widget class="QProgressBar" name="progressBar">
-      <property name="geometry">
-       <rect>
-        <x>0</x>
-        <y>270</y>
-        <width>201</width>
-        <height>23</height>
-       </rect>
-      </property>
-      <property name="value">
-       <number>0</number>
-      </property>
-     </widget>
-    </widget>
-    <widget class="QWidget" name="pNeuronsParam">
-     <property name="geometry">
-      <rect>
-       <x>0</x>
-       <y>0</y>
-       <width>201</width>
-       <height>293</height>
-      </rect>
-     </property>
-     <attribute name="label">
-      <string>Neurons parameters</string>
-     </attribute>
-     <widget class="QLabel" name="lblThreshold">
-      <property name="geometry">
-       <rect>
-        <x>10</x>
-        <y>180</y>
-        <width>71</width>
-        <height>20</height>
-       </rect>
-      </property>
-      <property name="text">
-       <string>Threshold:</string>
-      </property>
-     </widget>
-     <widget class="QDoubleSpinBox" name="dsbThreshold">
-      <property name="geometry">
-       <rect>
-        <x>80</x>
-        <y>180</y>
-        <width>101</width>
-        <height>27</height>
-       </rect>
-      </property>
-      <property name="accelerated">
-       <bool>true</bool>
-      </property>
-      <property name="decimals">
-       <number>10</number>
-      </property>
-      <property name="minimum">
-       <double>-99.989999999999995</double>
-      </property>
-      <property name="singleStep">
-       <double>0.001000000000000</double>
-      </property>
-      <property name="value">
-       <double>0.001000000000000</double>
-      </property>
-     </widget>
-     <widget class="QLabel" name="lblState">
-      <property name="geometry">
-       <rect>
-        <x>10</x>
-        <y>150</y>
-        <width>57</width>
-        <height>18</height>
-       </rect>
-      </property>
-      <property name="text">
-       <string>State:</string>
-      </property>
-     </widget>
-     <widget class="QLabel" name="lblNeuronTemperature">
-      <property name="geometry">
-       <rect>
-        <x>10</x>
-        <y>70</y>
-        <width>71</width>
-        <height>20</height>
-       </rect>
-      </property>
-      <property name="text">
-       <string>Temperature:</string>
-      </property>
-     </widget>
-     <widget class="QDoubleSpinBox" name="dsbNeuronTemperature">
-      <property name="geometry">
-       <rect>
-        <x>100</x>
-        <y>70</y>
-        <width>81</width>
-        <height>27</height>
-       </rect>
-      </property>
-      <property name="decimals">
-       <number>10</number>
-      </property>
-      <property name="maximum">
-       <double>10000000000.000000000000000</double>
-      </property>
-      <property name="singleStep">
-       <double>0.001000000000000</double>
-      </property>
-      <property name="value">
-       <double>0.000000000000000</double>
-      </property>
-     </widget>
-     <widget class="QSpinBox" name="sbNbStates">
-      <property name="geometry">
-       <rect>
-        <x>120</x>
-        <y>110</y>
-        <width>61</width>
-        <height>27</height>
-       </rect>
-      </property>
-      <property name="minimum">
-       <number>2</number>
-      </property>
-      <property name="value">
-       <number>2</number>
-      </property>
-     </widget>
-     <widget class="QLabel" name="lblStateNumber">
-      <property name="geometry">
-       <rect>
-        <x>10</x>
-        <y>110</y>
-        <width>91</width>
-        <height>18</height>
-       </rect>
-      </property>
-      <property name="text">
-       <string>Number of states:</string>
-      </property>
-     </widget>
-     <widget class="QComboBox" name="cmbState">
-      <property name="geometry">
-       <rect>
-        <x>90</x>
-        <y>140</y>
-        <width>91</width>
-        <height>26</height>
-       </rect>
-      </property>
-     </widget>
-     <widget class="QLineEdit" name="txtNodeID">
-      <property name="geometry">
-       <rect>
-        <x>70</x>
-        <y>40</y>
-        <width>111</width>
-        <height>27</height>
-       </rect>
-      </property>
-     </widget>
-     <widget class="QLabel" name="lblLabel">
-      <property name="geometry">
-       <rect>
-        <x>10</x>
-        <y>40</y>
-        <width>61</width>
-        <height>18</height>
-       </rect>
-      </property>
-      <property name="text">
-       <string>Node Id:</string>
-      </property>
-     </widget>
-     <widget class="QLabel" name="lblCurrent">
-      <property name="geometry">
-       <rect>
-        <x>10</x>
-        <y>13</y>
-        <width>51</width>
-        <height>20</height>
-       </rect>
-      </property>
-      <property name="text">
-       <string>Index:</string>
-      </property>
-     </widget>
-     <widget class="QLineEdit" name="txtIndex">
-      <property name="geometry">
-       <rect>
-        <x>70</x>
-        <y>10</y>
-        <width>113</width>
-        <height>27</height>
-       </rect>
-      </property>
-     </widget>
-    </widget>
-    <widget class="QWidget" name="pSynapsesParam">
-     <property name="geometry">
-      <rect>
-       <x>0</x>
-       <y>0</y>
-       <width>201</width>
-       <height>293</height>
-      </rect>
-     </property>
-     <attribute name="label">
-      <string>Synapses parameters</string>
-     </attribute>
-     <widget class="QDoubleSpinBox" name="dsbWeight">
-      <property name="geometry">
-       <rect>
-        <x>111</x>
-        <y>10</y>
-        <width>71</width>
-        <height>27</height>
-       </rect>
-      </property>
-      <property name="accelerated">
-       <bool>true</bool>
-      </property>
-      <property name="decimals">
-       <number>3</number>
-      </property>
-      <property name="minimum">
-       <double>-99.989999999999995</double>
-      </property>
-      <property name="singleStep">
-       <double>0.001000000000000</double>
-      </property>
-      <property name="value">
-       <double>1.000000000000000</double>
-      </property>
-     </widget>
-     <widget class="QLabel" name="lblWeight">
-      <property name="geometry">
-       <rect>
-        <x>10</x>
-        <y>10</y>
-        <width>101</width>
-        <height>20</height>
-       </rect>
-      </property>
-      <property name="text">
-       <string>Weight:</string>
-      </property>
-     </widget>
-     <widget class="QSpinBox" name="sbDelay">
-      <property name="geometry">
-       <rect>
-        <x>110</x>
-        <y>50</y>
-        <width>71</width>
-        <height>27</height>
-       </rect>
-      </property>
-      <property name="maximum">
-       <number>10000</number>
-      </property>
-     </widget>
-     <widget class="QLabel" name="lblDelay">
-      <property name="geometry">
-       <rect>
-        <x>10</x>
-        <y>50</y>
-        <width>48</width>
-        <height>18</height>
-       </rect>
-      </property>
-      <property name="text">
-       <string>Delay:</string>
-      </property>
-     </widget>
-    </widget>
-    <widget class="QWidget" name="pUpdateSchedule">
-     <property name="geometry">
-      <rect>
-       <x>0</x>
-       <y>0</y>
-       <width>201</width>
-       <height>293</height>
-      </rect>
-     </property>
-     <attribute name="label">
-      <string>Update schedule</string>
-     </attribute>
-     <widget class="QLabel" name="lblUpdateBlock">
-      <property name="geometry">
-       <rect>
-        <x>10</x>
-        <y>40</y>
-        <width>91</width>
-        <height>18</height>
-       </rect>
-      </property>
-      <property name="text">
-       <string>Update block:</string>
-      </property>
-     </widget>
-     <widget class="QLabel" name="lblUpdateMethods">
-      <property name="geometry">
-       <rect>
-        <x>10</x>
-        <y>70</y>
-        <width>101</width>
-        <height>18</height>
-       </rect>
-      </property>
-      <property name="text">
-       <string>Update Methods:</string>
-      </property>
-     </widget>
-     <widget class="QLabel" name="lblScheduleType">
-      <property name="geometry">
-       <rect>
-        <x>10</x>
-        <y>10</y>
-        <width>91</width>
-        <height>18</height>
-       </rect>
-      </property>
-      <property name="text">
-       <string>Type of schedule:</string>
-      </property>
-     </widget>
-     <widget class="QComboBox" name="cmbUpdateBlock">
-      <property name="geometry">
-       <rect>
-        <x>100</x>
-        <y>30</y>
-        <width>91</width>
-        <height>26</height>
-       </rect>
-      </property>
-     </widget>
-     <widget class="QComboBox" name="cmbScheduleType">
-      <property name="geometry">
-       <rect>
-        <x>100</x>
-        <y>0</y>
-        <width>91</width>
-        <height>26</height>
-       </rect>
-      </property>
-     </widget>
-     <widget class="QComboBox" name="cmbUpdateMethods">
-      <property name="geometry">
-       <rect>
-        <x>120</x>
-        <y>60</y>
-        <width>71</width>
-        <height>26</height>
-       </rect>
-      </property>
-     </widget>
-    </widget>
-   </widget>
-   <widget class="DesignPlan" name="frmDesign" native="true">
-    <property name="geometry">
-     <rect>
-      <x>220</x>
-      <y>50</y>
-      <width>551</width>
-      <height>461</height>
-     </rect>
-    </property>
-    <property name="mouseTracking">
-     <bool>true</bool>
-    </property>
-   </widget>
+    </item>
+   </layout>
   </widget>
   <widget class="QMenuBar" name="menubar">
    <property name="geometry">
     <rect>
      <x>0</x>
      <y>0</y>
-     <width>782</width>
-     <height>25</height>
+     <width>960</width>
+     <height>28</height>
     </rect>
    </property>
    <widget class="QMenu" name="menuFile">
@@ -665,45 +598,72 @@
    <property name="text">
     <string>&amp;New</string>
    </property>
+   <property name="shortcut">
+    <string>Ctrl+N</string>
+   </property>
   </action>
   <action name="actionO_pen">
    <property name="text">
-    <string>O&amp;pen</string>
+    <string>&amp;Open...</string>
+   </property>
+   <property name="shortcut">
+    <string>Ctrl+O</string>
    </property>
   </action>
   <action name="action_Save">
    <property name="text">
     <string>&amp;Save</string>
    </property>
+   <property name="shortcut">
+    <string>Ctrl+S</string>
+   </property>
   </action>
   <action name="actionSave_As">
    <property name="text">
     <string>Save &amp;As...</string>
    </property>
+   <property name="shortcut">
+    <string>Ctrl+Shift+S</string>
+   </property>
   </action>
   <action name="actionCut">
    <property name="text">
-    <string>Cut</string>
+    <string>Cu&amp;t</string>
+   </property>
+   <property name="shortcut">
+    <string>Ctrl+X</string>
    </property>
   </action>
   <action name="actionCopy">
    <property name="text">
-    <string>Copy</string>
+    <string>&amp;Copy</string>
+   </property>
+   <property name="shortcut">
+    <string>Ctrl+C</string>
    </property>
   </action>
   <action name="actionPaste">
    <property name="text">
-    <string>Paste</string>
+    <string>&amp;Paste</string>
+   </property>
+   <property name="shortcut">
+    <string>Ctrl+V</string>
    </property>
   </action>
   <action name="actionDelete">
    <property name="text">
-    <string>Delete</string>
+    <string>&amp;Delete</string>
+   </property>
+   <property name="shortcut">
+    <string>Del</string>
    </property>
   </action>
   <action name="actionSelect_All">
    <property name="text">
-    <string>Select all</string>
+    <string>Select &amp;All</string>
+   </property>
+   <property name="shortcut">
+    <string>Ctrl+A</string>
    </property>
   </action>
   <action name="actionSelect_borders">
@@ -729,6 +689,9 @@
   <action name="action_Quit">
    <property name="text">
     <string>&amp;Quit</string>
+   </property>
+   <property name="shortcut">
+    <string>Ctrl+Q</string>
    </property>
   </action>
  </widget>

--- a/networkdesigner.cpp
+++ b/networkdesigner.cpp
@@ -7,10 +7,9 @@
 #include <QtGui/QLabel>
 #include <QtGui/QPixmap>
 #include <QtGui/QStatusBar>
+#include <QtGui/QApplication>
 
 // Helper: load an SVG from Qt resources as a fixed-size QIcon.
-// Qt renders SVGs natively if Qt SVG module is available; otherwise
-// QPixmap will load the file and display it at its natural size.
 static QIcon svgIcon(const QString& path, int size = 20) {
     QPixmap pm(size, size);
     pm.load(path);
@@ -48,11 +47,17 @@ NetworkDesigner::NetworkDesigner(QWidget *parent) : QMainWindow(parent)
     setupToolBar();
     setupStatusBar();
 
-    // Update status bar whenever the network changes
+    // Network change → update counters
     connect(ui.frmDesign, SIGNAL(networkIsModified()), this, SLOT(updateStatusBar()));
     connect(ui.frmDesign, SIGNAL(updateCalled()),      this, SLOT(updateStatusBar()));
-    connect(ui.pbStart,   SIGNAL(clicked(bool)),       this, SLOT(updateStatusBar()));
-    connect(ui.pbStop,    SIGNAL(clicked(bool)),       this, SLOT(updateStatusBar()));
+
+    // Canvas mouse position → coordinates label
+    connect(ui.frmDesign, SIGNAL(canvasMouseMoved(int,int)),
+            this, SLOT(onCanvasMouseMoved(int,int)));
+
+    // Simulation state indicator via Start / Stop buttons
+    connect(ui.pbStart, SIGNAL(clicked(bool)), this, SLOT(onSimulationStarted()));
+    connect(ui.pbStop,  SIGNAL(clicked(bool)), this, SLOT(onSimulationFinished()));
 
     updateStatusBar();
 }
@@ -66,41 +71,55 @@ void NetworkDesigner::setupToolBar() {
     toolbar->setIconSize(QSize(20, 20));
     toolbar->setToolButtonStyle(Qt::ToolButtonTextUnderIcon);
 
-    // Style the toolbar itself via object name so the QSS can target it
-    toolbar->setStyleSheet(
-        "QToolBar { background:#181825; border-bottom:1px solid #313244; padding:2px 4px; spacing:4px; }"
-        "QToolButton { background:transparent; color:#a6adc8; border:none; border-radius:5px;"
-        "              padding:3px 8px; font-size:10px; }"
-        "QToolButton:hover  { background:#313244; color:#cdd6f4; }"
-        "QToolButton:pressed { background:#45475a; }"
-        "QToolBar::separator { background:#313244; width:1px; margin:4px 6px; }"
-    );
-
     auto addTB = [&](QAction* action, const QString& iconPath, const QString& tip) {
         action->setIcon(svgIcon(iconPath));
         action->setToolTip(tip);
         toolbar->addAction(action);
     };
 
-    addTB(ui.action_New,  ":/resources/icons/new.svg",  "New");
-    addTB(ui.actionO_pen, ":/resources/icons/open.svg", "Open");
-    addTB(ui.action_Save, ":/resources/icons/save.svg", "Save");
+    addTB(ui.action_New,  ":/resources/icons/new.svg",  "New\nCtrl+N");
+    addTB(ui.actionO_pen, ":/resources/icons/open.svg", "Open\nCtrl+O");
+    addTB(ui.action_Save, ":/resources/icons/save.svg", "Save\nCtrl+S");
 
     toolbar->addSeparator();
 
-    addTB(ui.actionDelete, ":/resources/icons/delete.svg", "Delete");
+    addTB(ui.actionDelete, ":/resources/icons/delete.svg", "Delete\nDel");
 
     toolbar->addSeparator();
 
-    // Start / Stop — wire directly to the panel buttons so signals still fire
+    // Start / Stop — proxy signals to the panel buttons
     auto* actStart = toolbar->addAction(svgIcon(":/resources/icons/start.svg"), "Start");
-    actStart->setToolTip("Run simulation (Ctrl+R)");
+    actStart->setToolTip("Run simulation\nCtrl+R");
     actStart->setShortcut(QKeySequence("Ctrl+R"));
     connect(actStart, SIGNAL(triggered(bool)), ui.pbStart, SIGNAL(clicked(bool)));
 
     auto* actStop = toolbar->addAction(svgIcon(":/resources/icons/stop.svg"), "Stop");
     actStop->setToolTip("Stop simulation");
     connect(actStop, SIGNAL(triggered(bool)), ui.pbStop, SIGNAL(clicked(bool)));
+
+    toolbar->addSeparator();
+
+    // Zoom controls
+    auto* actZoomIn = toolbar->addAction("+");
+    actZoomIn->setToolTip("Zoom in\n+");
+    actZoomIn->setShortcut(QKeySequence("+"));
+    connect(actZoomIn, &QAction::triggered, [this] {
+        double s = ui.frmDesign->getScale();
+        if (s + 0.1 <= 2.0) ui.frmDesign->setScale(s + 0.1);
+    });
+
+    auto* actZoomOut = toolbar->addAction("−");
+    actZoomOut->setToolTip("Zoom out\n−");
+    actZoomOut->setShortcut(QKeySequence("-"));
+    connect(actZoomOut, &QAction::triggered, [this] {
+        double s = ui.frmDesign->getScale();
+        if (s - 0.1 > 0.1) ui.frmDesign->setScale(s - 0.1);
+    });
+
+    auto* actReset = toolbar->addAction("1:1");
+    actReset->setToolTip("Reset view\nCtrl+0");
+    actReset->setShortcut(QKeySequence("Ctrl+0"));
+    connect(actReset, SIGNAL(triggered(bool)), ui.frmDesign, SLOT(resetView()));
 }
 
 // ── Status bar ────────────────────────────────────────────────────────────────
@@ -108,52 +127,87 @@ void NetworkDesigner::setupToolBar() {
 void NetworkDesigner::setupStatusBar() {
     QStatusBar* sb = statusBar();
 
-    // Left side: simulation state
-    statusSimState = new QLabel("  Idle  ");
-    statusSimState->setStyleSheet("color:#a6e3a1; font-size:11px; padding:0 8px;");
+    // Left: simulation state pill
+    statusSimState = new QLabel("  ● Idle  ");
+    statusSimState->setStyleSheet(
+        "color:#a6e3a1; font-size:11px; padding:0 8px; background:transparent;");
     sb->addWidget(statusSimState);
 
-    // Spacer to push permanent widgets to the right
+    // Separator
+    QFrame* sep = new QFrame();
+    sep->setFrameShape(QFrame::VLine);
+    sep->setFrameShadow(QFrame::Sunken);
+    sep->setStyleSheet("color:#313244;");
+    sb->addWidget(sep);
+
+    // Canvas coordinates
+    statusCoords = new QLabel("  x: 0  y: 0  ");
+    statusCoords->setStyleSheet(
+        "color:#6c7086; font-size:11px; font-family:monospace; padding:0 4px; background:transparent;");
+    statusCoords->setMinimumWidth(120);
+    sb->addWidget(statusCoords);
+
+    // Spacer
     QLabel* spacer = new QLabel();
     spacer->setSizePolicy(QSizePolicy::Expanding, QSizePolicy::Preferred);
     sb->addWidget(spacer);
 
-    // Permanent: neuron count with icon label
+    // Neuron count
     QLabel* iconN = new QLabel();
-    QPixmap pmN(12, 12);
-    pmN.load(":/resources/icons/neuron.svg");
+    QPixmap pmN(12, 12); pmN.load(":/resources/icons/neuron.svg");
     iconN->setPixmap(pmN);
-    iconN->setStyleSheet("padding:0 2px 0 8px;");
+    iconN->setStyleSheet("padding:0 2px 0 8px; background:transparent;");
     sb->addPermanentWidget(iconN);
 
     statusNeurons = new QLabel("0 neurons");
-    statusNeurons->setStyleSheet("color:#89b4fa; font-size:11px; padding:0 6px 0 0;");
+    statusNeurons->setStyleSheet(
+        "color:#89b4fa; font-size:11px; padding:0 6px 0 0; background:transparent;");
     sb->addPermanentWidget(statusNeurons);
 
-    // Permanent: synapse count with icon label
+    // Synapse count
     QLabel* iconS = new QLabel();
-    QPixmap pmS(12, 12);
-    pmS.load(":/resources/icons/synapse.svg");
+    QPixmap pmS(12, 12); pmS.load(":/resources/icons/synapse.svg");
     iconS->setPixmap(pmS);
-    iconS->setStyleSheet("padding:0 2px 0 8px;");
+    iconS->setStyleSheet("padding:0 2px 0 8px; background:transparent;");
     sb->addPermanentWidget(iconS);
 
     statusSynapses = new QLabel("0 synapses");
-    statusSynapses->setStyleSheet("color:#cba6f7; font-size:11px; padding:0 8px 0 0;");
+    statusSynapses->setStyleSheet(
+        "color:#cba6f7; font-size:11px; padding:0 8px 0 0; background:transparent;");
     sb->addPermanentWidget(statusSynapses);
 }
+
+// ── Slots ─────────────────────────────────────────────────────────────────────
 
 void NetworkDesigner::updateStatusBar() {
     if (!network) return;
 
-    // Count total synapses across all neurons
     int totalSynapses = 0;
     for (int i = 0; i < network->getNbNeurons(); ++i)
         totalSynapses += network->getNeuron(i)->getNb_neighbors();
 
     const int n = network->getNbNeurons();
     statusNeurons->setText(QString("%1 neuron%2").arg(n).arg(n != 1 ? "s" : ""));
-    statusSynapses->setText(QString("%1 synapse%2").arg(totalSynapses).arg(totalSynapses != 1 ? "s" : ""));
+    statusSynapses->setText(
+        QString("%1 synapse%2").arg(totalSynapses).arg(totalSynapses != 1 ? "s" : ""));
+}
+
+void NetworkDesigner::onCanvasMouseMoved(int worldX, int worldY) {
+    statusCoords->setText(QString("  x: %1  y: %2  ").arg(worldX).arg(worldY));
+}
+
+void NetworkDesigner::onSimulationStarted() {
+    statusSimState->setText("  ● Simulating…  ");
+    statusSimState->setStyleSheet(
+        "color:#fab387; font-size:11px; padding:0 8px; background:transparent;");
+    QApplication::processEvents(); // flush UI before blocking simulation
+}
+
+void NetworkDesigner::onSimulationFinished() {
+    statusSimState->setText("  ● Idle  ");
+    statusSimState->setStyleSheet(
+        "color:#a6e3a1; font-size:11px; padding:0 8px; background:transparent;");
+    updateStatusBar();
 }
 
 // ── Getters / setters ─────────────────────────────────────────────────────────

--- a/networkdesigner.cpp
+++ b/networkdesigner.cpp
@@ -1,73 +1,183 @@
 #include "networkdesigner.h"
 #include "NetworkDesignerParser.h"
 #include <QtGui/QMainWindow>
+#include <QtGui/QToolBar>
+#include <QtGui/QAction>
+#include <QtGui/QIcon>
+#include <QtGui/QLabel>
+#include <QtGui/QPixmap>
+#include <QtGui/QStatusBar>
+
+// Helper: load an SVG from Qt resources as a fixed-size QIcon.
+// Qt renders SVGs natively if Qt SVG module is available; otherwise
+// QPixmap will load the file and display it at its natural size.
+static QIcon svgIcon(const QString& path, int size = 20) {
+    QPixmap pm(size, size);
+    pm.load(path);
+    return QIcon(pm);
+}
 
 NetworkDesigner::NetworkDesigner(QWidget *parent) : QMainWindow(parent)
 {
-	ui.setupUi(this);
+    ui.setupUi(this);
 
-	//network = new Network(1);
-
-	//ui.frmDesign->setNetwork(network);
-
-	QStringList qslScheduleTypes;
-
+    QStringList qslScheduleTypes;
     qslScheduleTypes << "Parallel" << "Block Parallel" << "Block Sequential" << "Sequential";
-	ui.cmbScheduleType->insertItems((int)-1, qslScheduleTypes);
-	ui.cmbUpdateBlock->insertItem((int)-1, "Add a new block...");
+    ui.cmbScheduleType->insertItems(-1, qslScheduleTypes);
+    ui.cmbUpdateBlock->insertItem(-1, "Add a new block...");
 
-	QStringList qslUpdateMethods;
-	qslUpdateMethods << "Compute" << "Fixe" << "All to 1"
-		<< "All to 0" << "Alternate 01" << "Alternate 10" << "Randomly";
-	ui.cmbUpdateMethods->insertItems((int)-1, qslUpdateMethods);
+    QStringList qslUpdateMethods;
+    qslUpdateMethods << "Compute" << "Fixe" << "All to 1"
+                     << "All to 0" << "Alternate 01" << "Alternate 10" << "Randomly";
+    ui.cmbUpdateMethods->insertItems(-1, qslUpdateMethods);
 
-	QStringList qslSimulations;
-	qslSimulations << "No simulation" << "Activity analysis" << "Changement analysis" << "Diffusion analysis" << "Attractor and basins" << "Attractor and basins V2";
-	ui.cmbSimulationType->insertItems((int)-1, qslSimulations);
+    QStringList qslSimulations;
+    qslSimulations << "No simulation" << "Activity analysis" << "Changement analysis"
+                   << "Diffusion analysis" << "Attractor and basins" << "Attractor and basins V2";
+    ui.cmbSimulationType->insertItems(-1, qslSimulations);
 
-    /*
-    ui.cmbScheduleType->insertItem((int)-1, "Block Parallel");
-    ui.cmbScheduleType->insertItem((int)-1, "Block Sequential");
-   	ui.cmbScheduleType->insertItem((int)-1, "Parallel");
-    ui.cmbScheduleType->insertItem((int)-1, "Sequential");
-    */
     setWindowTitle("Network Designer");
 
-//	ui.frmDesign->load("test.nml");
+    network = ui.frmDesign->getNetwork();
+    updateSchedulingPlan = ui.frmDesign->getUpdateSchedulingPlan();
 
-	network = ui.frmDesign->getNetwork();
-	updateSchedulingPlan = ui.frmDesign->getUpdateSchedulingPlan();
+    evenementHandler = new EvenementHandler(&ui, network, updateSchedulingPlan);
+    ssc = new SignalsSlotsConnector(evenementHandler, &ui, this);
+    evenementHandler->updateMe();
 
-	evenementHandler = new EvenementHandler(&ui, network, updateSchedulingPlan);
-	ssc = new SignalsSlotsConnector(evenementHandler, &ui, this);
-//	evenementHandler->setFileName("test.nml");
-	evenementHandler->updateMe();
-	//evenementHandler->fileUpdated();
-	//evenementHandler->fileWasModified();
+    setupToolBar();
+    setupStatusBar();
+
+    // Update status bar whenever the network changes
+    connect(ui.frmDesign, SIGNAL(networkIsModified()), this, SLOT(updateStatusBar()));
+    connect(ui.frmDesign, SIGNAL(updateCalled()),      this, SLOT(updateStatusBar()));
+    connect(ui.pbStart,   SIGNAL(clicked(bool)),       this, SLOT(updateStatusBar()));
+    connect(ui.pbStop,    SIGNAL(clicked(bool)),       this, SLOT(updateStatusBar()));
+
+    updateStatusBar();
 }
 
-Network * NetworkDesigner::getNetwork() const{
-	return network;
+// ── Toolbar ──────────────────────────────────────────────────────────────────
+
+void NetworkDesigner::setupToolBar() {
+    QToolBar* toolbar = addToolBar("Main");
+    toolbar->setObjectName("mainToolBar");
+    toolbar->setMovable(false);
+    toolbar->setIconSize(QSize(20, 20));
+    toolbar->setToolButtonStyle(Qt::ToolButtonTextUnderIcon);
+
+    // Style the toolbar itself via object name so the QSS can target it
+    toolbar->setStyleSheet(
+        "QToolBar { background:#181825; border-bottom:1px solid #313244; padding:2px 4px; spacing:4px; }"
+        "QToolButton { background:transparent; color:#a6adc8; border:none; border-radius:5px;"
+        "              padding:3px 8px; font-size:10px; }"
+        "QToolButton:hover  { background:#313244; color:#cdd6f4; }"
+        "QToolButton:pressed { background:#45475a; }"
+        "QToolBar::separator { background:#313244; width:1px; margin:4px 6px; }"
+    );
+
+    auto addTB = [&](QAction* action, const QString& iconPath, const QString& tip) {
+        action->setIcon(svgIcon(iconPath));
+        action->setToolTip(tip);
+        toolbar->addAction(action);
+    };
+
+    addTB(ui.action_New,  ":/resources/icons/new.svg",  "New");
+    addTB(ui.actionO_pen, ":/resources/icons/open.svg", "Open");
+    addTB(ui.action_Save, ":/resources/icons/save.svg", "Save");
+
+    toolbar->addSeparator();
+
+    addTB(ui.actionDelete, ":/resources/icons/delete.svg", "Delete");
+
+    toolbar->addSeparator();
+
+    // Start / Stop — wire directly to the panel buttons so signals still fire
+    auto* actStart = toolbar->addAction(svgIcon(":/resources/icons/start.svg"), "Start");
+    actStart->setToolTip("Run simulation (Ctrl+R)");
+    actStart->setShortcut(QKeySequence("Ctrl+R"));
+    connect(actStart, SIGNAL(triggered(bool)), ui.pbStart, SIGNAL(clicked(bool)));
+
+    auto* actStop = toolbar->addAction(svgIcon(":/resources/icons/stop.svg"), "Stop");
+    actStop->setToolTip("Stop simulation");
+    connect(actStop, SIGNAL(triggered(bool)), ui.pbStop, SIGNAL(clicked(bool)));
 }
 
-void NetworkDesigner::setNetwork(Network* network){
-	this->network = network;
-	ui.frmDesign->setNetwork(network);
+// ── Status bar ────────────────────────────────────────────────────────────────
+
+void NetworkDesigner::setupStatusBar() {
+    QStatusBar* sb = statusBar();
+
+    // Left side: simulation state
+    statusSimState = new QLabel("  Idle  ");
+    statusSimState->setStyleSheet("color:#a6e3a1; font-size:11px; padding:0 8px;");
+    sb->addWidget(statusSimState);
+
+    // Spacer to push permanent widgets to the right
+    QLabel* spacer = new QLabel();
+    spacer->setSizePolicy(QSizePolicy::Expanding, QSizePolicy::Preferred);
+    sb->addWidget(spacer);
+
+    // Permanent: neuron count with icon label
+    QLabel* iconN = new QLabel();
+    QPixmap pmN(12, 12);
+    pmN.load(":/resources/icons/neuron.svg");
+    iconN->setPixmap(pmN);
+    iconN->setStyleSheet("padding:0 2px 0 8px;");
+    sb->addPermanentWidget(iconN);
+
+    statusNeurons = new QLabel("0 neurons");
+    statusNeurons->setStyleSheet("color:#89b4fa; font-size:11px; padding:0 6px 0 0;");
+    sb->addPermanentWidget(statusNeurons);
+
+    // Permanent: synapse count with icon label
+    QLabel* iconS = new QLabel();
+    QPixmap pmS(12, 12);
+    pmS.load(":/resources/icons/synapse.svg");
+    iconS->setPixmap(pmS);
+    iconS->setStyleSheet("padding:0 2px 0 8px;");
+    sb->addPermanentWidget(iconS);
+
+    statusSynapses = new QLabel("0 synapses");
+    statusSynapses->setStyleSheet("color:#cba6f7; font-size:11px; padding:0 8px 0 0;");
+    sb->addPermanentWidget(statusSynapses);
 }
 
-UpdateSchedulingPlan * NetworkDesigner::getUpdateSchedulingplan() const{
-	return updateSchedulingPlan;
+void NetworkDesigner::updateStatusBar() {
+    if (!network) return;
+
+    // Count total synapses across all neurons
+    int totalSynapses = 0;
+    for (int i = 0; i < network->getNbNeurons(); ++i)
+        totalSynapses += network->getNeuron(i)->getNb_neighbors();
+
+    const int n = network->getNbNeurons();
+    statusNeurons->setText(QString("%1 neuron%2").arg(n).arg(n != 1 ? "s" : ""));
+    statusSynapses->setText(QString("%1 synapse%2").arg(totalSynapses).arg(totalSynapses != 1 ? "s" : ""));
 }
 
-void NetworkDesigner::setUpdateSchedulingPlan(UpdateSchedulingPlan * updateSchedulingPlan){
-	this->updateSchedulingPlan = updateSchedulingPlan;
-	ui.frmDesign->setUpdateSchedulingPlan(updateSchedulingPlan);
+// ── Getters / setters ─────────────────────────────────────────────────────────
+
+Network* NetworkDesigner::getNetwork() const { return network; }
+
+void NetworkDesigner::setNetwork(Network* network) {
+    this->network = network;
+    ui.frmDesign->setNetwork(network);
+    updateStatusBar();
 }
 
-NetworkDesigner::~NetworkDesigner(){
-	for(int i=0; i<network->getNbNeurons();i++){
-		network->delNeuron(i);
-	}
-	delete ssc;
-	delete evenementHandler;
+UpdateSchedulingPlan* NetworkDesigner::getUpdateSchedulingplan() const {
+    return updateSchedulingPlan;
+}
+
+void NetworkDesigner::setUpdateSchedulingPlan(UpdateSchedulingPlan* usp) {
+    updateSchedulingPlan = usp;
+    ui.frmDesign->setUpdateSchedulingPlan(usp);
+}
+
+NetworkDesigner::~NetworkDesigner() {
+    for (int i = 0; i < network->getNbNeurons(); ++i)
+        network->delNeuron(i);
+    delete ssc;
+    delete evenementHandler;
 }

--- a/networkdesigner.h
+++ b/networkdesigner.h
@@ -28,6 +28,9 @@ public:
 
 public slots:
     void updateStatusBar();
+    void onCanvasMouseMoved(int worldX, int worldY);
+    void onSimulationStarted();
+    void onSimulationFinished();
 
 private:
     void setupToolBar();
@@ -44,6 +47,7 @@ private:
     QLabel * statusNeurons;
     QLabel * statusSynapses;
     QLabel * statusSimState;
+    QLabel * statusCoords;
 };
 
 #endif // NETWORKDESIGNER_H

--- a/networkdesigner.h
+++ b/networkdesigner.h
@@ -2,6 +2,9 @@
 #define NETWORKDESIGNER_H
 
 #include <QtGui/QWidget>
+#include <QtGui/QToolBar>
+#include <QtGui/QLabel>
+#include <QtGui/QPixmap>
 #include "ui_mainWindow.h"
 #include "NetworkDesignerParser.h"
 #include "EvenementHandler.h"
@@ -14,23 +17,33 @@ class NetworkDesigner : public QMainWindow
 public:
     NetworkDesigner(QWidget *parent = 0);
     ~NetworkDesigner();
-    
+
     Network * getNetwork() const;
     void setNetwork(Network * network);
-    
+
     UpdateSchedulingPlan * getUpdateSchedulingplan() const;
- 	void setUpdateSchedulingPlan(UpdateSchedulingPlan * updateSchedulingPlan);
-	
-	void load(char * path);    
-	 
+    void setUpdateSchedulingPlan(UpdateSchedulingPlan * updateSchedulingPlan);
+
+    void load(char * path);
+
+public slots:
+    void updateStatusBar();
+
 private:
+    void setupToolBar();
+    void setupStatusBar();
+
     Ui::MainWindow ui;
     Network * network;
     UpdateSchedulingPlan * updateSchedulingPlan;
- 
+
     EvenementHandler * evenementHandler;
     SignalsSlotsConnector * ssc;
 
+    // Status bar widgets
+    QLabel * statusNeurons;
+    QLabel * statusSynapses;
+    QLabel * statusSimState;
 };
 
 #endif // NETWORKDESIGNER_H

--- a/resources.qrc
+++ b/resources.qrc
@@ -1,0 +1,5 @@
+<RCC>
+    <qresource prefix="/">
+        <file>resources/style.qss</file>
+    </qresource>
+</RCC>

--- a/resources.qrc
+++ b/resources.qrc
@@ -1,5 +1,13 @@
 <RCC>
     <qresource prefix="/">
         <file>resources/style.qss</file>
+        <file>resources/icons/new.svg</file>
+        <file>resources/icons/open.svg</file>
+        <file>resources/icons/save.svg</file>
+        <file>resources/icons/delete.svg</file>
+        <file>resources/icons/start.svg</file>
+        <file>resources/icons/stop.svg</file>
+        <file>resources/icons/neuron.svg</file>
+        <file>resources/icons/synapse.svg</file>
     </qresource>
 </RCC>

--- a/resources/icons/delete.svg
+++ b/resources/icons/delete.svg
@@ -1,0 +1,5 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="20" height="20" viewBox="0 0 20 20" fill="none">
+  <path d="M4 6h12M8 6V4h4v2" stroke="#f38ba8" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"/>
+  <rect x="5" y="6" width="10" height="10" rx="1.5" stroke="#f38ba8" stroke-width="1.5"/>
+  <path d="M8 9v4M12 9v4" stroke="#f38ba8" stroke-width="1.5" stroke-linecap="round"/>
+</svg>

--- a/resources/icons/neuron.svg
+++ b/resources/icons/neuron.svg
@@ -1,0 +1,4 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="16" height="16" viewBox="0 0 16 16" fill="none">
+  <circle cx="8" cy="8" r="5" stroke="#89b4fa" stroke-width="1.5"/>
+  <circle cx="8" cy="8" r="2" fill="#89b4fa"/>
+</svg>

--- a/resources/icons/new.svg
+++ b/resources/icons/new.svg
@@ -1,0 +1,5 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="20" height="20" viewBox="0 0 20 20" fill="none">
+  <rect x="3" y="1" width="11" height="15" rx="1.5" stroke="#cdd6f4" stroke-width="1.5"/>
+  <path d="M11 1v5h5" stroke="#cdd6f4" stroke-width="1.5" stroke-linecap="round"/>
+  <path d="M7 10h6M7 13h4" stroke="#89b4fa" stroke-width="1.5" stroke-linecap="round"/>
+</svg>

--- a/resources/icons/open.svg
+++ b/resources/icons/open.svg
@@ -1,0 +1,4 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="20" height="20" viewBox="0 0 20 20" fill="none">
+  <path d="M2 6a2 2 0 012-2h4l2 2h6a2 2 0 012 2v7a2 2 0 01-2 2H4a2 2 0 01-2-2V6z" stroke="#cdd6f4" stroke-width="1.5" stroke-linejoin="round"/>
+  <path d="M2 9h16" stroke="#89b4fa" stroke-width="1.5" stroke-linecap="round"/>
+</svg>

--- a/resources/icons/save.svg
+++ b/resources/icons/save.svg
@@ -1,0 +1,5 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="20" height="20" viewBox="0 0 20 20" fill="none">
+  <rect x="2" y="2" width="16" height="16" rx="2" stroke="#cdd6f4" stroke-width="1.5"/>
+  <rect x="6" y="2" width="8" height="6" rx="1" stroke="#89b4fa" stroke-width="1.5"/>
+  <rect x="5" y="11" width="10" height="5" rx="1" stroke="#cdd6f4" stroke-width="1.5"/>
+</svg>

--- a/resources/icons/start.svg
+++ b/resources/icons/start.svg
@@ -1,0 +1,4 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="20" height="20" viewBox="0 0 20 20" fill="none">
+  <circle cx="10" cy="10" r="8" stroke="#a6e3a1" stroke-width="1.5"/>
+  <path d="M8 7l6 3-6 3V7z" fill="#a6e3a1"/>
+</svg>

--- a/resources/icons/stop.svg
+++ b/resources/icons/stop.svg
@@ -1,0 +1,4 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="20" height="20" viewBox="0 0 20 20" fill="none">
+  <circle cx="10" cy="10" r="8" stroke="#f38ba8" stroke-width="1.5"/>
+  <rect x="7" y="7" width="6" height="6" rx="1" fill="#f38ba8"/>
+</svg>

--- a/resources/icons/synapse.svg
+++ b/resources/icons/synapse.svg
@@ -1,0 +1,6 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="16" height="16" viewBox="0 0 16 16" fill="none">
+  <circle cx="3" cy="8" r="2.5" stroke="#cba6f7" stroke-width="1.2"/>
+  <circle cx="13" cy="8" r="2.5" stroke="#cba6f7" stroke-width="1.2"/>
+  <path d="M5.5 8h3.5" stroke="#cba6f7" stroke-width="1.2" stroke-linecap="round"/>
+  <path d="M9 6l2 2-2 2" stroke="#cba6f7" stroke-width="1.2" stroke-linecap="round" stroke-linejoin="round"/>
+</svg>

--- a/resources/style.qss
+++ b/resources/style.qss
@@ -1,0 +1,378 @@
+/* =====================================================
+   NetworkDesigner — Modern Dark Theme
+   ===================================================== */
+
+/* ---------- Global ---------- */
+QWidget {
+    background-color: #1e1e2e;
+    color: #cdd6f4;
+    font-family: "Segoe UI", "Inter", "SF Pro Display", sans-serif;
+    font-size: 12px;
+    selection-background-color: #89b4fa;
+    selection-color: #1e1e2e;
+}
+
+QMainWindow {
+    background-color: #181825;
+}
+
+/* ---------- Menu bar ---------- */
+QMenuBar {
+    background-color: #181825;
+    color: #cdd6f4;
+    padding: 2px 4px;
+    border-bottom: 1px solid #313244;
+}
+
+QMenuBar::item {
+    padding: 4px 10px;
+    border-radius: 4px;
+}
+
+QMenuBar::item:selected {
+    background-color: #313244;
+}
+
+QMenuBar::item:pressed {
+    background-color: #45475a;
+}
+
+QMenu {
+    background-color: #24273a;
+    border: 1px solid #313244;
+    border-radius: 6px;
+    padding: 4px 0;
+}
+
+QMenu::item {
+    padding: 6px 24px 6px 12px;
+}
+
+QMenu::item:selected {
+    background-color: #313244;
+    border-radius: 4px;
+}
+
+QMenu::separator {
+    height: 1px;
+    background-color: #313244;
+    margin: 4px 8px;
+}
+
+/* ---------- Status bar ---------- */
+QStatusBar {
+    background-color: #181825;
+    color: #a6adc8;
+    border-top: 1px solid #313244;
+    font-size: 11px;
+}
+
+/* ---------- ToolBox (side panel) ---------- */
+QToolBox {
+    background-color: #1e1e2e;
+    border-right: 1px solid #313244;
+}
+
+QToolBox::tab {
+    background-color: #181825;
+    color: #89b4fa;
+    font-weight: 600;
+    font-size: 11px;
+    letter-spacing: 0.5px;
+    padding: 6px 10px;
+    border: none;
+    border-bottom: 1px solid #313244;
+    border-radius: 0;
+    text-transform: uppercase;
+}
+
+QToolBox::tab:selected {
+    background-color: #313244;
+    color: #cba6f7;
+    border-left: 3px solid #cba6f7;
+}
+
+QToolBox::tab:hover {
+    background-color: #24273a;
+}
+
+/* ---------- Labels ---------- */
+QLabel {
+    color: #a6adc8;
+    font-size: 11px;
+}
+
+/* ---------- Inputs (SpinBox, LineEdit, ComboBox) ---------- */
+QSpinBox,
+QDoubleSpinBox,
+QLineEdit {
+    background-color: #313244;
+    color: #cdd6f4;
+    border: 1px solid #45475a;
+    border-radius: 5px;
+    padding: 3px 6px;
+    min-height: 22px;
+    selection-background-color: #89b4fa;
+    selection-color: #1e1e2e;
+}
+
+QSpinBox:focus,
+QDoubleSpinBox:focus,
+QLineEdit:focus {
+    border: 1px solid #89b4fa;
+    outline: none;
+}
+
+QSpinBox:hover,
+QDoubleSpinBox:hover,
+QLineEdit:hover {
+    border: 1px solid #585b70;
+}
+
+QSpinBox::up-button,
+QDoubleSpinBox::up-button {
+    subcontrol-origin: border;
+    subcontrol-position: top right;
+    width: 16px;
+    border-left: 1px solid #45475a;
+    border-bottom: 1px solid #45475a;
+    border-top-right-radius: 5px;
+    background-color: #45475a;
+}
+
+QSpinBox::down-button,
+QDoubleSpinBox::down-button {
+    subcontrol-origin: border;
+    subcontrol-position: bottom right;
+    width: 16px;
+    border-left: 1px solid #45475a;
+    border-top: 1px solid #45475a;
+    border-bottom-right-radius: 5px;
+    background-color: #45475a;
+}
+
+QSpinBox::up-button:hover,
+QDoubleSpinBox::up-button:hover,
+QSpinBox::down-button:hover,
+QDoubleSpinBox::down-button:hover {
+    background-color: #585b70;
+}
+
+QSpinBox::up-arrow,
+QDoubleSpinBox::up-arrow {
+    image: none;
+    width: 6px;
+    height: 6px;
+    border-left: 3px solid transparent;
+    border-right: 3px solid transparent;
+    border-bottom: 4px solid #cdd6f4;
+}
+
+QSpinBox::down-arrow,
+QDoubleSpinBox::down-arrow {
+    image: none;
+    width: 6px;
+    height: 6px;
+    border-left: 3px solid transparent;
+    border-right: 3px solid transparent;
+    border-top: 4px solid #cdd6f4;
+}
+
+/* ---------- ComboBox ---------- */
+QComboBox {
+    background-color: #313244;
+    color: #cdd6f4;
+    border: 1px solid #45475a;
+    border-radius: 5px;
+    padding: 3px 6px;
+    min-height: 22px;
+}
+
+QComboBox:focus {
+    border: 1px solid #89b4fa;
+}
+
+QComboBox:hover {
+    border: 1px solid #585b70;
+}
+
+QComboBox::drop-down {
+    subcontrol-origin: padding;
+    subcontrol-position: top right;
+    width: 20px;
+    border-left: 1px solid #45475a;
+    border-top-right-radius: 5px;
+    border-bottom-right-radius: 5px;
+    background-color: #45475a;
+}
+
+QComboBox::down-arrow {
+    width: 6px;
+    height: 6px;
+    border-left: 3px solid transparent;
+    border-right: 3px solid transparent;
+    border-top: 4px solid #cdd6f4;
+}
+
+QComboBox QAbstractItemView {
+    background-color: #24273a;
+    color: #cdd6f4;
+    border: 1px solid #45475a;
+    border-radius: 5px;
+    selection-background-color: #45475a;
+    selection-color: #cdd6f4;
+    outline: none;
+    padding: 2px;
+}
+
+/* ---------- CheckBox ---------- */
+QCheckBox {
+    color: #a6adc8;
+    spacing: 6px;
+}
+
+QCheckBox::indicator {
+    width: 14px;
+    height: 14px;
+    border: 1px solid #45475a;
+    border-radius: 3px;
+    background-color: #313244;
+}
+
+QCheckBox::indicator:checked {
+    background-color: #89b4fa;
+    border: 1px solid #89b4fa;
+}
+
+QCheckBox::indicator:hover {
+    border: 1px solid #89b4fa;
+}
+
+/* ---------- Push Buttons ---------- */
+QPushButton {
+    background-color: #45475a;
+    color: #cdd6f4;
+    border: 1px solid #585b70;
+    border-radius: 6px;
+    padding: 5px 14px;
+    font-weight: 600;
+    min-height: 26px;
+}
+
+QPushButton:hover {
+    background-color: #585b70;
+    border-color: #89b4fa;
+}
+
+QPushButton:pressed {
+    background-color: #313244;
+    border-color: #89b4fa;
+}
+
+/* Start button — accent color */
+QPushButton#pbStart {
+    background-color: #a6e3a1;
+    color: #1e1e2e;
+    border: none;
+    font-weight: 700;
+}
+
+QPushButton#pbStart:hover {
+    background-color: #94e2a0;
+}
+
+QPushButton#pbStart:pressed {
+    background-color: #81d4a0;
+}
+
+/* Stop button — red accent */
+QPushButton#pbStop {
+    background-color: #f38ba8;
+    color: #1e1e2e;
+    border: none;
+    font-weight: 700;
+}
+
+QPushButton#pbStop:hover {
+    background-color: #f5a0b8;
+}
+
+QPushButton#pbStop:pressed {
+    background-color: #e07090;
+}
+
+/* ---------- Progress Bar ---------- */
+QProgressBar {
+    background-color: #313244;
+    border: 1px solid #45475a;
+    border-radius: 5px;
+    text-align: center;
+    color: #cdd6f4;
+    font-size: 10px;
+    min-height: 14px;
+}
+
+QProgressBar::chunk {
+    background-color: #89b4fa;
+    border-radius: 4px;
+}
+
+/* ---------- ScrollBar ---------- */
+QScrollBar:vertical {
+    background-color: #1e1e2e;
+    width: 8px;
+    margin: 0;
+}
+
+QScrollBar::handle:vertical {
+    background-color: #45475a;
+    border-radius: 4px;
+    min-height: 24px;
+}
+
+QScrollBar::handle:vertical:hover {
+    background-color: #585b70;
+}
+
+QScrollBar::add-line:vertical,
+QScrollBar::sub-line:vertical {
+    height: 0;
+}
+
+QScrollBar:horizontal {
+    background-color: #1e1e2e;
+    height: 8px;
+    margin: 0;
+}
+
+QScrollBar::handle:horizontal {
+    background-color: #45475a;
+    border-radius: 4px;
+    min-width: 24px;
+}
+
+QScrollBar::handle:horizontal:hover {
+    background-color: #585b70;
+}
+
+QScrollBar::add-line:horizontal,
+QScrollBar::sub-line:horizontal {
+    width: 0;
+}
+
+/* ---------- ToolTips ---------- */
+QToolTip {
+    background-color: #24273a;
+    color: #cdd6f4;
+    border: 1px solid #45475a;
+    border-radius: 4px;
+    padding: 4px 8px;
+    font-size: 11px;
+}
+
+/* ---------- Design canvas ---------- */
+DesignPlan {
+    background-color: #11111b;
+    border: 1px solid #313244;
+    border-radius: 4px;
+}

--- a/resources/style.qss
+++ b/resources/style.qss
@@ -376,3 +376,41 @@ DesignPlan {
     border: 1px solid #313244;
     border-radius: 4px;
 }
+
+/* ---------- Toolbar ---------- */
+QToolBar {
+    background-color: #181825;
+    border-bottom: 1px solid #313244;
+    padding: 2px 4px;
+    spacing: 4px;
+}
+
+QToolBar::separator {
+    background: #313244;
+    width: 1px;
+    margin: 4px 6px;
+}
+
+QToolButton {
+    background: transparent;
+    color: #a6adc8;
+    border: none;
+    border-radius: 5px;
+    padding: 3px 8px;
+    font-size: 10px;
+}
+
+QToolButton:hover {
+    background: #313244;
+    color: #cdd6f4;
+}
+
+QToolButton:pressed {
+    background: #45475a;
+}
+
+/* ---------- Status bar (override for child labels) ---------- */
+QStatusBar QLabel {
+    font-size: 11px;
+    background: transparent;
+}


### PR DESCRIPTION
## Summary

- **Build system**: Migrated from qmake to CMake 3.16+ with Qt6/Qt5 auto-detection
- **Dark theme**: Catppuccin Mocha palette via Qt Style Sheets (QSS), embedded in Qt resource system
- **Rendering**: Antialiased neurons (radial gradient, drop shadow, selection glow), semantic synapse colors, gradient canvas background with adaptive dot grid
- **UI layout**: Replaced all fixed-pixel geometry with QHBoxLayout/QVBoxLayout; responsive canvas with keyboard shortcuts and tooltips
- **Toolbar**: 7 SVG icons (New, Open, Save, Delete, Start, Stop) + zoom controls (Ctrl+R, +/−, Ctrl+0) + reset view
- **Status bar**: Live neuron/synapse counters, canvas coordinates, simulation state indicator
- **Contextual cursors**: 5 cursor states (drag, hover neuron, hover synapse, draw synapse, default)
- **C++17 refactor**: Member-initializer lists, `std::find_if`, lambdas, extracted helper methods in Computer.cpp
- **Memory leak fix**: `UpdateSchedulingPlan` destructor now properly deletes owned `UpdateBlock*` pointers
- **Specs**: Added SPECS.md retro-documenting functional specifications for iso-functional reference

## Test plan

- [ ] Build with `cmake -B build && cmake --build build` (requires Qt5 or Qt6 dev libs)
- [ ] Open/save a .nml network file — verify round-trip
- [ ] Add neurons and synapses via click/drag, delete via Del key
- [ ] Run each simulation type (Parallel, Block Parallel, Sequential, Block Sequential)
- [ ] Verify zoom in/out and reset view (Ctrl+0)
- [ ] Confirm status bar updates neuron/synapse counts on network changes

---
_Generated by [Claude Code](https://claude.ai/code/session_01YQiX1sW6GgnyH4seTsEZbg)_