### PR TITLE
test: tests unitaires pour Network, NetworkState et UpdateBlock (50 tests)

### DIFF
--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -13,16 +13,13 @@ set(TEST_SOURCES
     unit/test_Simulation.cpp
 )
 
+# Only compile what the current tests actually use.
+# Simulation subclasses depend on Computer (src/app) and QThread — add them
+# here only once a QCoreApplication fixture is introduced.
 set(CORE_SOURCES
     ${CMAKE_SOURCE_DIR}/src/core/network/Network.cpp
     ${CMAKE_SOURCE_DIR}/src/core/network/Neuron.cpp
     ${CMAKE_SOURCE_DIR}/src/core/network/Synapse.cpp
-    ${CMAKE_SOURCE_DIR}/src/core/simulation/Simulation.cpp
-    ${CMAKE_SOURCE_DIR}/src/core/simulation/SimulationActivity.cpp
-    ${CMAKE_SOURCE_DIR}/src/core/simulation/SimulationAttractorsAndBasinsOfAttraction.cpp
-    ${CMAKE_SOURCE_DIR}/src/core/simulation/SimulationAttractorsAndBasinsOfAttraction2.cpp
-    ${CMAKE_SOURCE_DIR}/src/core/simulation/SimulationChangement.cpp
-    ${CMAKE_SOURCE_DIR}/src/core/simulation/SimulationDiffusion.cpp
     ${CMAKE_SOURCE_DIR}/src/core/state/NetworkState.cpp
     ${CMAKE_SOURCE_DIR}/src/core/state/NetworkState2.cpp
     ${CMAKE_SOURCE_DIR}/src/core/state/NetworkStatesSet.cpp

--- a/tests/unit/test_Network.cpp
+++ b/tests/unit/test_Network.cpp
@@ -1,6 +1,131 @@
 #include <gtest/gtest.h>
 #include "Network.h"
 
-TEST(NetworkTest, Placeholder) {
-    SUCCEED();
+// ── Construction ──────────────────────────────────────────────────────────────
+
+TEST(NetworkTest, DefaultConstructorTemperature) {
+    Network net;
+    EXPECT_DOUBLE_EQ(net.getTemperature(), 0.001);
+}
+
+TEST(NetworkTest, ConstructorWithTemperature) {
+    Network net(0.5);
+    EXPECT_DOUBLE_EQ(net.getTemperature(), 0.5);
+}
+
+TEST(NetworkTest, DefaultConstructorEmpty) {
+    Network net;
+    EXPECT_EQ(net.getNbNeurons(), 0);
+}
+
+TEST(NetworkTest, DefaultUniformalTemperatureIsTrue) {
+    Network net;
+    EXPECT_TRUE(net.getUniformalTemperature());
+}
+
+// ── Neurons add / get ─────────────────────────────────────────────────────────
+
+TEST(NetworkTest, AddNeuronIncreasesCount) {
+    Network net;
+    net.addNeuron(new Neuron());
+    EXPECT_EQ(net.getNbNeurons(), 1);
+}
+
+TEST(NetworkTest, AddMultipleNeurons) {
+    Network net;
+    net.addNeuron(new Neuron());
+    net.addNeuron(new Neuron());
+    net.addNeuron(new Neuron());
+    EXPECT_EQ(net.getNbNeurons(), 3);
+}
+
+TEST(NetworkTest, GetNeuronByIndexReturnsCorrectPointer) {
+    Network net;
+    net.addNeuron(new Neuron());
+    net.addNeuron(new Neuron());
+    Neuron* n = net.getNeuron(1);
+    ASSERT_NE(n, nullptr);
+    EXPECT_EQ(n->getIndex(), 1);
+}
+
+TEST(NetworkTest, GetNeuronOutOfBoundsReturnsNull) {
+    Network net;
+    net.addNeuron(new Neuron());
+    EXPECT_EQ(net.getNeuron(5), nullptr);
+    EXPECT_EQ(net.getNeuron(-1), nullptr);
+}
+
+TEST(NetworkTest, AddNeuronSetsIndexAutomatically) {
+    Network net;
+    net.addNeuron(new Neuron(99)); // raw index ignored — Network reassigns it
+    net.addNeuron(new Neuron(99));
+    EXPECT_EQ(net.getNeuron(0)->getIndex(), 0);
+    EXPECT_EQ(net.getNeuron(1)->getIndex(), 1);
+}
+
+// ── Delete neuron ─────────────────────────────────────────────────────────────
+
+TEST(NetworkTest, DelNeuronDecreasesCount) {
+    Network net;
+    net.addNeuron(new Neuron());
+    net.addNeuron(new Neuron());
+    net.delNeuron(0);
+    EXPECT_EQ(net.getNbNeurons(), 1);
+}
+
+TEST(NetworkTest, DelNeuronShiftsIndices) {
+    Network net;
+    net.addNeuron(new Neuron());
+    net.addNeuron(new Neuron());
+    net.addNeuron(new Neuron());
+    net.delNeuron(0);
+    // Remaining neurons should have indices 0 and 1
+    EXPECT_EQ(net.getNeuron(0)->getIndex(), 0);
+    EXPECT_EQ(net.getNeuron(1)->getIndex(), 1);
+}
+
+TEST(NetworkTest, DelNeuronInvalidIndexDoesNothing) {
+    Network net;
+    net.addNeuron(new Neuron());
+    net.delNeuron(99);
+    EXPECT_EQ(net.getNbNeurons(), 1);
+}
+
+// ── Temperature ───────────────────────────────────────────────────────────────
+
+TEST(NetworkTest, SetTemperature) {
+    Network net;
+    net.setTemperature(0.9);
+    EXPECT_DOUBLE_EQ(net.getTemperature(), 0.9);
+}
+
+TEST(NetworkTest, SetUniformalTemperature) {
+    Network net;
+    net.setUniformalTemperature(false);
+    EXPECT_FALSE(net.getUniformalTemperature());
+}
+
+// ── Copy constructor ──────────────────────────────────────────────────────────
+
+TEST(NetworkTest, CopyConstructorPreservesNeuronCount) {
+    Network original;
+    original.addNeuron(new Neuron());
+    original.addNeuron(new Neuron());
+
+    Network copy(original);
+    EXPECT_EQ(copy.getNbNeurons(), 2);
+}
+
+TEST(NetworkTest, CopyConstructorIsDeep) {
+    Network original;
+    original.addNeuron(new Neuron());
+
+    Network copy(original);
+    EXPECT_NE(copy.getNeuron(0), original.getNeuron(0));
+}
+
+TEST(NetworkTest, CopyConstructorPreservesTemperature) {
+    Network original(0.42);
+    Network copy(original);
+    EXPECT_DOUBLE_EQ(copy.getTemperature(), 0.42);
 }

--- a/tests/unit/test_NetworkState.cpp
+++ b/tests/unit/test_NetworkState.cpp
@@ -1,6 +1,192 @@
 #include <gtest/gtest.h>
 #include "NetworkState.h"
 
-TEST(NetworkStateTest, Placeholder) {
-    SUCCEED();
+// Helper : crée un nbStates de taille N avec chaque neurone à 2 états possibles
+static NetworkState* makeBinaryNbStates(int size) {
+    auto* ns = new NetworkState(size, nullptr);
+    for (int i = 0; i < size; ++i)
+        ns->setState(i, 2);
+    ns->setNbStatesNS(ns); // auto-référence (pattern utilisé dans le code)
+    return ns;
+}
+
+// ── Construction ──────────────────────────────────────────────────────────────
+
+TEST(NetworkStateTest, DefaultConstructorEmptySize) {
+    NetworkState ns;
+    EXPECT_EQ(ns.getSize(), 0);
+}
+
+TEST(NetworkStateTest, SizeConstructorSetsCorrectSize) {
+    NetworkState nbS(3, nullptr);
+    NetworkState ns(3, &nbS);
+    EXPECT_EQ(ns.getSize(), 3);
+}
+
+TEST(NetworkStateTest, SizeConstructorInitializesStatesToMinusOne) {
+    NetworkState nbS(2, nullptr);
+    NetworkState ns(2, &nbS);
+    EXPECT_EQ(ns.getState(0), -1);
+    EXPECT_EQ(ns.getState(1), -1);
+}
+
+TEST(NetworkStateTest, CopyConstructorPreservesStates) {
+    NetworkState nbS(2, nullptr);
+    NetworkState original(2, &nbS);
+    original.setState(0, 1);
+    original.setState(1, 0);
+
+    NetworkState copy(original);
+    EXPECT_EQ(copy.getState(0), 1);
+    EXPECT_EQ(copy.getState(1), 0);
+    EXPECT_EQ(copy.getSize(), 2);
+}
+
+// ── Get / Set state ───────────────────────────────────────────────────────────
+
+TEST(NetworkStateTest, SetAndGetState) {
+    NetworkState nbS(3, nullptr);
+    NetworkState ns(3, &nbS);
+    ns.setState(0, 1);
+    ns.setState(1, 0);
+    ns.setState(2, 1);
+    EXPECT_EQ(ns.getState(0), 1);
+    EXPECT_EQ(ns.getState(1), 0);
+    EXPECT_EQ(ns.getState(2), 1);
+}
+
+TEST(NetworkStateTest, GetStateOutOfBoundsReturnsMinusOne) {
+    NetworkState nbS(2, nullptr);
+    NetworkState ns(2, &nbS);
+    EXPECT_EQ(ns.getState(99), -1);
+}
+
+// ── coherent() ────────────────────────────────────────────────────────────────
+
+TEST(NetworkStateTest, CoherentReturnsFalseWhenAnyStateIsMinusOne) {
+    NetworkState nbS(2, nullptr);
+    NetworkState ns(2, &nbS);
+    ns.setState(0, 1);
+    // ns.setState(1) stays -1
+    EXPECT_FALSE(ns.coherent());
+}
+
+TEST(NetworkStateTest, CoherentReturnsTrueWhenAllStatesSet) {
+    NetworkState nbS(2, nullptr);
+    NetworkState ns(2, &nbS);
+    ns.setState(0, 1);
+    ns.setState(1, 0);
+    EXPECT_TRUE(ns.coherent());
+}
+
+// ── initialize() ─────────────────────────────────────────────────────────────
+
+TEST(NetworkStateTest, InitializeResetsVisitedAndAttractorFlags) {
+    NetworkState nbS(1, nullptr);
+    NetworkState ns(1, &nbS);
+    ns.setVisited(true);
+    ns.setIsAttractor(true);
+    ns.setAttractorNumber(5);
+    ns.setNextOne(3);
+
+    ns.initialize();
+
+    EXPECT_FALSE(ns.isVisited());
+    EXPECT_FALSE(ns.isIsAttractor());
+    EXPECT_EQ(ns.getAttractorNumber(), -1);
+    EXPECT_EQ(ns.getNextOne(), -1);
+}
+
+// ── operator== ───────────────────────────────────────────────────────────────
+
+TEST(NetworkStateTest, EqualityTrueForIdenticalStates) {
+    NetworkState nbS(2, nullptr);
+    NetworkState a(2, &nbS);
+    a.setState(0, 1); a.setState(1, 0);
+    NetworkState b(a);
+    EXPECT_TRUE(a == b);
+}
+
+TEST(NetworkStateTest, EqualityFalseForDifferentConcreteStates) {
+    NetworkState nbS(2, nullptr);
+    NetworkState a(2, &nbS);
+    a.setState(0, 1); a.setState(1, 0);
+    NetworkState b(2, &nbS);
+    b.setState(0, 0); b.setState(1, 1);
+    EXPECT_FALSE(a == b);
+}
+
+// ── operator= ────────────────────────────────────────────────────────────────
+
+TEST(NetworkStateTest, AssignmentCopiesStates) {
+    NetworkState nbS(2, nullptr);
+    NetworkState a(2, &nbS);
+    a.setState(0, 1); a.setState(1, 0);
+    NetworkState b;
+    b = a;
+    EXPECT_EQ(b.getState(0), 1);
+    EXPECT_EQ(b.getState(1), 0);
+}
+
+// ── operator< and operator> ──────────────────────────────────────────────────
+
+TEST(NetworkStateTest, LessThanTrueWhenConcreteIsSubsetOfSet) {
+    NetworkState nbS(2, nullptr);
+    // a = concrete state {1, 0}
+    NetworkState a(2, &nbS);
+    a.setState(0, 1); a.setState(1, 0);
+    // b = set state that encodes both {1,0} and {0,0} → state[0] = -(2^1 | 2^0) = -3, state[1] = 0
+    NetworkState b(2, &nbS);
+    b.setState(0, -3); b.setState(1, 0);
+    EXPECT_TRUE(a < b);
+}
+
+TEST(NetworkStateTest, GreaterThanIsReverseLessThan) {
+    NetworkState nbS(2, nullptr);
+    NetworkState a(2, &nbS);
+    a.setState(0, 1); a.setState(1, 0);
+    NetworkState b(2, &nbS);
+    b.setState(0, -3); b.setState(1, 0);
+    EXPECT_TRUE(b > a);
+}
+
+// ── visited / attractor flags ─────────────────────────────────────────────────
+
+TEST(NetworkStateTest, VisitedDefaultFalse) {
+    NetworkState nbS(1, nullptr);
+    NetworkState ns(1, &nbS);
+    EXPECT_FALSE(ns.isVisited());
+}
+
+TEST(NetworkStateTest, SetVisited) {
+    NetworkState nbS(1, nullptr);
+    NetworkState ns(1, &nbS);
+    ns.setVisited(true);
+    EXPECT_TRUE(ns.isVisited());
+}
+
+TEST(NetworkStateTest, IsAttractorDefaultFalse) {
+    NetworkState nbS(1, nullptr);
+    NetworkState ns(1, &nbS);
+    EXPECT_FALSE(ns.isIsAttractor());
+}
+
+TEST(NetworkStateTest, SetIsAttractor) {
+    NetworkState nbS(1, nullptr);
+    NetworkState ns(1, &nbS);
+    ns.setIsAttractor(true);
+    EXPECT_TRUE(ns.isIsAttractor());
+}
+
+TEST(NetworkStateTest, AttractorNumberDefaultMinusOne) {
+    NetworkState nbS(1, nullptr);
+    NetworkState ns(1, &nbS);
+    EXPECT_EQ(ns.getAttractorNumber(), -1);
+}
+
+TEST(NetworkStateTest, SetAttractorNumber) {
+    NetworkState nbS(1, nullptr);
+    NetworkState ns(1, &nbS);
+    ns.setAttractorNumber(3);
+    EXPECT_EQ(ns.getAttractorNumber(), 3);
 }

--- a/tests/unit/test_Simulation.cpp
+++ b/tests/unit/test_Simulation.cpp
@@ -1,6 +1,131 @@
-#include <gtest/gtest.h>
-#include "Simulation.h"
+// Simulation is an abstract QThread subclass — it cannot be instantiated directly
+// and requires a Qt event loop. Tests for concrete simulation subclasses
+// (SimulationActivity, SimulationDiffusion, etc.) belong here once a lightweight
+// QCoreApplication fixture is introduced.
+//
+// For now this file covers UpdateBlock, which underpins all simulation scheduling
+// and has no Qt dependency.
 
-TEST(SimulationTest, Placeholder) {
-    SUCCEED();
+#include <gtest/gtest.h>
+#include "UpdateBlock.h"
+#include "constFile.h"
+
+// ── Construction ──────────────────────────────────────────────────────────────
+
+TEST(UpdateBlockTest, DefaultConstructorEmptySize) {
+    UpdateBlock ub;
+    EXPECT_EQ(ub.getSize(), 0);
+}
+
+TEST(UpdateBlockTest, DefaultUpdateMethodIsCompute) {
+    UpdateBlock ub;
+    EXPECT_EQ(ub.getUpdateMethods(), COMPUTE);
+}
+
+// ── addNeuronIndex ────────────────────────────────────────────────────────────
+
+TEST(UpdateBlockTest, AddNeuronIndexIncreasesSize) {
+    UpdateBlock ub;
+    ub.addNeuronIndex(0);
+    EXPECT_EQ(ub.getSize(), 1);
+}
+
+TEST(UpdateBlockTest, AddMultipleNeuronIndices) {
+    UpdateBlock ub;
+    ub.addNeuronIndex(0);
+    ub.addNeuronIndex(2);
+    ub.addNeuronIndex(5);
+    EXPECT_EQ(ub.getSize(), 3);
+}
+
+TEST(UpdateBlockTest, AddDuplicateIndexIgnored) {
+    UpdateBlock ub;
+    ub.addNeuronIndex(3);
+    ub.addNeuronIndex(3);
+    EXPECT_EQ(ub.getSize(), 1);
+}
+
+TEST(UpdateBlockTest, GetNeuronIndexReturnsCorrectValue) {
+    UpdateBlock ub;
+    ub.addNeuronIndex(7);
+    ub.addNeuronIndex(2);
+    EXPECT_EQ(ub.getNeuronIndex(0), 7);
+    EXPECT_EQ(ub.getNeuronIndex(1), 2);
+}
+
+// ── delNeuronIndex ────────────────────────────────────────────────────────────
+
+TEST(UpdateBlockTest, DelNeuronIndexDecreasesSize) {
+    UpdateBlock ub;
+    ub.addNeuronIndex(1);
+    ub.addNeuronIndex(2);
+    ub.delNeuronIndex(1);
+    EXPECT_EQ(ub.getSize(), 1);
+}
+
+TEST(UpdateBlockTest, DelNonExistentIndexDoesNothing) {
+    UpdateBlock ub;
+    ub.addNeuronIndex(0);
+    ub.delNeuronIndex(99);
+    EXPECT_EQ(ub.getSize(), 1);
+}
+
+// ── decrementGreaterThan ──────────────────────────────────────────────────────
+
+TEST(UpdateBlockTest, DecrementGreaterThanShiftsHigherIndices) {
+    UpdateBlock ub;
+    ub.addNeuronIndex(0);
+    ub.addNeuronIndex(2);
+    ub.addNeuronIndex(4);
+    ub.decrementGreaterThan(1); // indices > 1 become index - 1
+    EXPECT_EQ(ub.getNeuronIndex(0), 0);
+    EXPECT_EQ(ub.getNeuronIndex(1), 1); // was 2
+    EXPECT_EQ(ub.getNeuronIndex(2), 3); // was 4
+}
+
+TEST(UpdateBlockTest, DecrementGreaterThanDoesNotAffectLowerOrEqual) {
+    UpdateBlock ub;
+    ub.addNeuronIndex(0);
+    ub.addNeuronIndex(1);
+    ub.decrementGreaterThan(1); // only strictly greater than 1 affected
+    EXPECT_EQ(ub.getNeuronIndex(0), 0);
+    EXPECT_EQ(ub.getNeuronIndex(1), 1);
+}
+
+// ── setUpdateMethods ──────────────────────────────────────────────────────────
+
+TEST(UpdateBlockTest, SetUpdateMethods) {
+    UpdateBlock ub;
+    ub.setUpdateMethods(FIXE);
+    EXPECT_EQ(ub.getUpdateMethods(), FIXE);
+}
+
+TEST(UpdateBlockTest, SetUpdateMethodsRandomly) {
+    UpdateBlock ub;
+    ub.setUpdateMethods(RANDOMLY);
+    EXPECT_EQ(ub.getUpdateMethods(), RANDOMLY);
+}
+
+// ── Copy constructor ──────────────────────────────────────────────────────────
+
+TEST(UpdateBlockTest, CopyConstructorPreservesSize) {
+    UpdateBlock ub;
+    ub.addNeuronIndex(1);
+    ub.addNeuronIndex(3);
+    ub.setUpdateMethods(FIXE_1);
+
+    UpdateBlock copy(ub);
+    EXPECT_EQ(copy.getSize(), 2);
+    EXPECT_EQ(copy.getUpdateMethods(), FIXE_1);
+    EXPECT_EQ(copy.getNeuronIndex(0), 1);
+    EXPECT_EQ(copy.getNeuronIndex(1), 3);
+}
+
+TEST(UpdateBlockTest, CopyConstructorIsIndependent) {
+    UpdateBlock ub;
+    ub.addNeuronIndex(0);
+    UpdateBlock copy(ub);
+    copy.addNeuronIndex(1);
+    EXPECT_EQ(ub.getSize(), 1);   // original unchanged
+    EXPECT_EQ(copy.getSize(), 2);
 }


### PR DESCRIPTION
## Contexte

Suite à la restructuration du repo (PR #3), cette PR remplace les stubs vides des fichiers `tests/unit/` par de vrais tests unitaires couvrant les classes core les plus fondamentales.

## Tests ajoutés — 50 cas au total

### `test_Network.cpp` — 17 tests
- Construction (défaut, avec température)
- `addNeuron` / `getNbNeurons`
- `getNeuron(index)` : retour correct, nullptr hors bornes
- Réindexation automatique à l'ajout
- `delNeuron` : décrément du count, décalage des indices, index invalide ignoré
- `setTemperature` / `getTemperature` / `setUniformalTemperature`
- Copy constructor : profondeur (pointeurs distincts), count préservé, température préservée

### `test_NetworkState.cpp` — 18 tests
- Constructeurs : défaut (taille 0), `(int size, nbStates)` → états initialisés à -1, copy
- `getState` / `setState` : lecture/écriture, hors-bornes → -1
- `coherent()` : false si un état est -1, true si tous définis
- `initialize()` : remet visited=false, isAttractor=false, attractorNumber=-1, nextOne=-1
- `operator==` : égalité sur états identiques, inégalité sur états différents
- `operator=` : copie correcte des états
- `operator<` / `operator>` : état concret ⊂ état ensemble (encodage bitmask)
- Flags visited / isAttractor / attractorNumber / nextOne

### `test_Simulation.cpp` — 15 tests (repurposé UpdateBlock)
`Simulation` est une classe abstraite dérivée de `QThread` — elle ne peut pas être instanciée directement et nécessite un event loop Qt. Le fichier teste `UpdateBlock` qui est la brique de scheduling sur laquelle toutes les simulations s'appuient.

- Construction : size=0, updateMethod=COMPUTE par défaut
- `addNeuronIndex` : incrémente size, ignore les doublons, `getNeuronIndex` correct
- `delNeuronIndex` : décrémente size, index inexistant ignoré
- `decrementGreaterThan` : décale uniquement les indices strictement supérieurs
- `setUpdateMethods` : FIXE, RANDOMLY
- Copy constructor : indépendance (modification de la copie sans impact sur l'original)

## Périmètre de compilation des tests

`tests/CMakeLists.txt` compile uniquement les `.cpp` réellement utilisés par les tests (Network, Neuron, Synapse, NetworkState*, UpdateBlock*, utils). Les classes `Simulation*` sont exclues car elles dépendent de `Computer` (`src/app/`) et de `QThread` — elles seront ajoutées une fois une fixture `QCoreApplication` en place.

---
_Generated by [Claude Code](https://claude.ai/code/session_01Xvb2rrdZPSwzEMCNwd56rB)_