### PR TITLE
ci: fix package libqt5xml5-dev introuvable sur Ubuntu 24.04

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -20,7 +20,6 @@ jobs:
           sudo apt-get install -y \
             qtbase5-dev \
             qtbase5-dev-tools \
-            libqt5xml5-dev \
             libgtest-dev \
             cmake \
             ninja-build


### PR DESCRIPTION
## Problème

`libqt5xml5-dev` n'existe plus sous ce nom sur Ubuntu 24.04 (Noble). Il a été renommé `libqt5xml5t64` et est tiré automatiquement comme dépendance de `qtbase5-dev`.

## Fix

Suppression de `libqt5xml5-dev` de la liste `apt-get install` dans `.github/workflows/ci.yml`.

---
_Generated by [Claude Code](https://claude.ai/code/session_01Xvb2rrdZPSwzEMCNwd56rB)_