### PR TITLE
fix: QtGui/QMessageBox → QtWidgets/QMessageBox

### DIFF
--- a/src/app/NetworkDesignerParser.cpp
+++ b/src/app/NetworkDesignerParser.cpp
@@ -3,7 +3,7 @@
 #include <QtXml/QDomElement>
 #include <QtXml/QDomNode>
 #include <QTextStream>
-#include <QtGui/QMessageBox>
+#include <QtWidgets/QMessageBox>
 #include <QFile>
 #include <iostream>
 #include <memory>


### PR DESCRIPTION
Dernier include `QtGui/` oublié dans `NetworkDesignerParser.cpp`.

---
_Generated by [Claude Code](https://claude.ai/code/session_01Xvb2rrdZPSwzEMCNwd56rB)_