### PR TITLE
Add Windows installer and Android APK build pipelines

### DIFF
--- a/.github/workflows/android.yml
+++ b/.github/workflows/android.yml
@@ -1,0 +1,97 @@
+name: Android – Build APK
+
+on:
+  push:
+    branches: [master, claude/networkdesigner-windows-mobile-kgdpz3]
+  pull_request:
+    branches: [master]
+  workflow_dispatch:
+    inputs:
+      create_release:
+        description: 'Create GitHub Release'
+        type: boolean
+        default: false
+
+jobs:
+  build-android:
+    name: Build APK (arm64-v8a, Qt6)
+    runs-on: ubuntu-latest
+
+    env:
+      ANDROID_NDK_VERSION: '25.1.8937393'
+      QT_VERSION: '6.7.3'
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Set up Java 17
+        uses: actions/setup-java@v4
+        with:
+          distribution: temurin
+          java-version: '17'
+
+      - name: Set up Android SDK / NDK
+        uses: android-actions/setup-android@v3
+
+      - name: Install NDK ${{ env.ANDROID_NDK_VERSION }}
+        run: |
+          sdkmanager "ndk;${{ env.ANDROID_NDK_VERSION }}"
+          echo "ANDROID_NDK_ROOT=$ANDROID_SDK_ROOT/ndk/${{ env.ANDROID_NDK_VERSION }}" >> $GITHUB_ENV
+
+      # Install Qt for Android (arm64) + host desktop tools in one step
+      - name: Install Qt for Android (arm64-v8a)
+        uses: jurplel/install-qt-action@v4
+        with:
+          version: ${{ env.QT_VERSION }}
+          host: 'linux'
+          target: 'android'
+          arch: 'android_arm64_v8a'
+          cache: true
+          extra: '--autodesktop'
+
+      - name: Configure (Android arm64)
+        run: |
+          cmake -B build-android \
+            -DCMAKE_TOOLCHAIN_FILE="$ANDROID_NDK_ROOT/build/cmake/android.toolchain.cmake" \
+            -DANDROID_ABI=arm64-v8a \
+            -DANDROID_PLATFORM=android-26 \
+            -DQT_HOST_PATH="$(dirname $(dirname $(which qmake)))" \
+            -DCMAKE_PREFIX_PATH="$QT_ROOT_DIR" \
+            -DCMAKE_BUILD_TYPE=Release \
+            -DBUILD_TESTS=OFF
+
+      - name: Build
+        run: cmake --build build-android --parallel
+
+      - name: Package APK with androiddeployqt
+        run: |
+          DEPLOY_JSON=$(find build-android -name "android-NetworkDesigner-deployment-settings.json" | head -1)
+          androiddeployqt \
+            --input "$DEPLOY_JSON" \
+            --output build-android/android-build \
+            --android-platform android-33 \
+            --jdk "$JAVA_HOME" \
+            --apk
+
+      - name: Locate APK
+        id: find-apk
+        run: |
+          APK=$(find build-android/android-build -name "*.apk" | head -1)
+          echo "apk_path=$APK" >> $GITHUB_OUTPUT
+
+      - name: Upload APK artifact
+        uses: actions/upload-artifact@v4
+        with:
+          name: NetworkDesigner-Android-APK
+          path: ${{ steps.find-apk.outputs.apk_path }}
+          retention-days: 30
+
+      - name: Create GitHub Release
+        if: github.event_name == 'workflow_dispatch' && inputs.create_release
+        uses: softprops/action-gh-release@v2
+        with:
+          tag_name: v1.0-android
+          name: NetworkDesigner 1.0 (Android)
+          files: ${{ steps.find-apk.outputs.apk_path }}
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/windows.yml
+++ b/.github/workflows/windows.yml
@@ -1,0 +1,105 @@
+name: Windows – Build & Installer
+
+on:
+  push:
+    branches: [master, claude/networkdesigner-windows-mobile-kgdpz3]
+  pull_request:
+    branches: [master]
+  workflow_dispatch:
+    inputs:
+      create_release:
+        description: 'Create GitHub Release'
+        type: boolean
+        default: false
+
+jobs:
+  build-windows:
+    name: Build (Windows, Qt6 MSVC)
+    runs-on: windows-latest
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Install Qt 6
+        uses: jurplel/install-qt-action@v4
+        with:
+          version: '6.7.3'
+          host: 'windows'
+          target: 'desktop'
+          arch: 'win64_msvc2022_64'
+          cache: true
+
+      - name: Configure (MSVC)
+        run: cmake -B build -DCMAKE_BUILD_TYPE=Release
+
+      - name: Build
+        run: cmake --build build --config Release --parallel
+
+      # Collect the exe + all Qt DLLs into a staging directory
+      - name: Stage with windeployqt
+        shell: pwsh
+        run: |
+          New-Item -ItemType Directory -Force staging
+          Copy-Item build\src\Release\NetworkDesigner.exe staging\
+          windeployqt --release staging\NetworkDesigner.exe
+
+      # Build an NSIS installer (.exe) from the staged files
+      - name: Install NSIS
+        run: choco install nsis --no-progress -y
+
+      - name: Write NSIS script
+        shell: pwsh
+        run: |
+          $script = @'
+          Unicode true
+          !define APP_NAME    "NetworkDesigner"
+          !define APP_VERSION "1.0"
+          !define APP_EXE     "NetworkDesigner.exe"
+
+          Name "${APP_NAME} ${APP_VERSION}"
+          OutFile "NetworkDesigner-Setup.exe"
+          InstallDir "$PROGRAMFILES64\${APP_NAME}"
+          InstallDirRegKey HKLM "Software\${APP_NAME}" "Install_Dir"
+          RequestExecutionLevel admin
+
+          Page directory
+          Page instfiles
+
+          Section "Application"
+            SetOutPath "$INSTDIR"
+            File /r "staging\*.*"
+            WriteRegStr HKLM "Software\${APP_NAME}" "Install_Dir" "$INSTDIR"
+            WriteUninstaller "$INSTDIR\Uninstall.exe"
+            CreateDirectory "$SMPROGRAMS\${APP_NAME}"
+            CreateShortcut "$SMPROGRAMS\${APP_NAME}\${APP_NAME}.lnk" "$INSTDIR\${APP_EXE}"
+            CreateShortcut "$DESKTOP\${APP_NAME}.lnk" "$INSTDIR\${APP_EXE}"
+          SectionEnd
+
+          Section "Uninstall"
+            DeleteRegKey HKLM "Software\${APP_NAME}"
+            RMDir /r "$INSTDIR"
+            Delete "$DESKTOP\${APP_NAME}.lnk"
+            RMDir /r "$SMPROGRAMS\${APP_NAME}"
+          SectionEnd
+          '@
+          $script | Out-File -Encoding UTF8 installer.nsi
+
+      - name: Build installer
+        run: makensis installer.nsi
+
+      - name: Upload installer artifact
+        uses: actions/upload-artifact@v4
+        with:
+          name: NetworkDesigner-Windows-Installer
+          path: NetworkDesigner-Setup.exe
+          retention-days: 30
+
+      - name: Create GitHub Release
+        if: github.event_name == 'workflow_dispatch' && inputs.create_release
+        uses: softprops/action-gh-release@v2
+        with:
+          tag_name: v1.0-windows
+          name: NetworkDesigner 1.0 (Windows)
+          files: NetworkDesigner-Setup.exe
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -23,5 +23,28 @@ endif()
 
 add_subdirectory(src)
 
-enable_testing()
-add_subdirectory(tests)
+# Tests are not built for Android (no GTest port)
+if(NOT ANDROID)
+    enable_testing()
+    add_subdirectory(tests)
+endif()
+
+# Android deployment descriptor consumed by androiddeployqt
+if(ANDROID)
+    include(${QT_ANDROID_CMAKE_FILE} OPTIONAL)
+    set_property(TARGET NetworkDesigner APPEND PROPERTY
+        QT_ANDROID_PACKAGE_SOURCE_DIR "${CMAKE_SOURCE_DIR}/android"
+    )
+endif()
+
+# CPack installer (Windows only)
+if(WIN32)
+    set(CPACK_GENERATOR "NSIS")
+    set(CPACK_PACKAGE_NAME "NetworkDesigner")
+    set(CPACK_PACKAGE_VENDOR "NetworkDesigner")
+    set(CPACK_PACKAGE_VERSION ${PROJECT_VERSION})
+    set(CPACK_PACKAGE_DESCRIPTION_SUMMARY "Discrete-state neural network design tool")
+    set(CPACK_NSIS_DISPLAY_NAME "NetworkDesigner")
+    set(CPACK_NSIS_ENABLE_UNINSTALL_BEFORE_INSTALL ON)
+    include(CPack)
+endif()

--- a/android/AndroidManifest.xml
+++ b/android/AndroidManifest.xml
@@ -1,0 +1,47 @@
+<?xml version="1.0" encoding="utf-8"?>
+<manifest xmlns:android="http://schemas.android.com/apk/res/android"
+    package="org.networkdesigner.app"
+    android:versionCode="1"
+    android:versionName="1.0">
+
+    <uses-sdk
+        android:minSdkVersion="26"
+        android:targetSdkVersion="33" />
+
+    <!-- Storage access for saving/loading .nml files -->
+    <uses-permission android:name="android.permission.READ_EXTERNAL_STORAGE"
+        android:maxSdkVersion="32"/>
+    <uses-permission android:name="android.permission.WRITE_EXTERNAL_STORAGE"
+        android:maxSdkVersion="29"/>
+    <uses-permission android:name="android.permission.MANAGE_EXTERNAL_STORAGE" />
+
+    <application
+        android:label="NetworkDesigner"
+        android:hardwareAccelerated="true"
+        android:largeHeap="true">
+
+        <activity
+            android:name="org.qtproject.qt.android.bindings.QtActivity"
+            android:label="NetworkDesigner"
+            android:theme="@style/Theme.AppCompat.NoActionBar"
+            android:screenOrientation="unspecified"
+            android:configChanges="orientation|uiMode|screenLayout|screenSize|smallestScreenSize|layoutDirection|locale|fontScale|keyboard|keyboardHidden|navigation|mcc|mnc|density"
+            android:exported="true">
+
+            <intent-filter>
+                <action android:name="android.intent.action.MAIN" />
+                <category android:name="android.intent.category.LAUNCHER" />
+            </intent-filter>
+
+            <!-- Open .nml files directly from file manager -->
+            <intent-filter>
+                <action android:name="android.intent.action.VIEW" />
+                <category android:name="android.intent.category.DEFAULT" />
+                <data android:scheme="file" android:mimeType="*/*" android:pathPattern=".*\\.nml" />
+            </intent-filter>
+
+            <meta-data android:name="android.app.lib_name" android:value="NetworkDesigner" />
+            <meta-data android:name="android.app.extract_android_style" android:value="minimal" />
+        </activity>
+    </application>
+</manifest>

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -57,4 +57,10 @@ target_compile_options(NetworkDesigner PRIVATE
     $<$<CXX_COMPILER_ID:GNU,Clang>:-Wall -Wextra -Wpedantic>
 )
 
+# No console window on Windows; bundle on macOS
+set_target_properties(NetworkDesigner PROPERTIES
+    WIN32_EXECUTABLE TRUE
+    MACOSX_BUNDLE TRUE
+)
+
 install(TARGETS NetworkDesigner RUNTIME DESTINATION bin)


### PR DESCRIPTION
## Summary

- Ajout d'un workflow GitHub Actions pour **Windows** : build Qt6/MSVC → windeployqt → installeur `.exe` NSIS
- Ajout d'un workflow GitHub Actions pour **Android** : cross-compile Qt6 arm64-v8a → `androiddeployqt` → APK
- Ajout de `android/AndroidManifest.xml` : déclaration de l'app Android (minSdk 26, association fichiers `.nml`)
- Mise à jour de `CMakeLists.txt` : skip tests sur Android, config CPack/NSIS Windows, set package source dir Android
- Mise à jour de `src/CMakeLists.txt` : `WIN32_EXECUTABLE TRUE` pour supprimer la console Windows

---
_Generated by [Claude Code](https://claude.ai/code/session_017ZMkpRE4LibVyGgeYZUgNK)_