### PR TITLE
Fix CI: Windows Qt arch + Android Qt path resolution

### DIFF
--- a/.github/workflows/android.yml
+++ b/.github/workflows/android.yml
@@ -38,7 +38,22 @@ jobs:
           sdkmanager "ndk;${{ env.ANDROID_NDK_VERSION }}"
           echo "ANDROID_NDK_ROOT=$ANDROID_SDK_ROOT/ndk/${{ env.ANDROID_NDK_VERSION }}" >> $GITHUB_ENV
 
-      # Install Qt for Android (arm64) + host desktop tools in one step
+      # Install Qt desktop (host tools: moc, uic, rcc, qmake)
+      - name: Install Qt desktop (host tools)
+        uses: jurplel/install-qt-action@v4
+        with:
+          version: ${{ env.QT_VERSION }}
+          host: 'linux'
+          target: 'desktop'
+          arch: 'linux_gcc_64'
+          cache: true
+          dir: '${{ github.workspace }}/Qt'
+          set-env: true
+
+      - name: Save Qt host path
+        run: echo "QT_HOST_PATH=$QT_ROOT_DIR" >> $GITHUB_ENV
+
+      # Install Qt for Android (arm64-v8a cross-compile libraries)
       - name: Install Qt for Android (arm64-v8a)
         uses: jurplel/install-qt-action@v4
         with:
@@ -47,16 +62,23 @@ jobs:
           target: 'android'
           arch: 'android_arm64_v8a'
           cache: true
-          extra: '--autodesktop'
+          dir: '${{ github.workspace }}/Qt'
+          set-env: true
 
       - name: Configure (Android arm64)
         run: |
+          # Locate Android Qt6 and host Qt6 installation roots
+          QT_ANDROID_ROOT="$QT_ROOT_DIR"
+          echo "Qt Android root: $QT_ANDROID_ROOT"
+          echo "Qt Host path:    $QT_HOST_PATH"
+
           cmake -B build-android \
             -DCMAKE_TOOLCHAIN_FILE="$ANDROID_NDK_ROOT/build/cmake/android.toolchain.cmake" \
             -DANDROID_ABI=arm64-v8a \
             -DANDROID_PLATFORM=android-26 \
-            -DQT_HOST_PATH="$(dirname $(dirname $(which qmake)))" \
-            -DCMAKE_PREFIX_PATH="$QT_ROOT_DIR" \
+            -DCMAKE_PREFIX_PATH="$QT_ANDROID_ROOT" \
+            -DQt6_DIR="$QT_ANDROID_ROOT/lib/cmake/Qt6" \
+            -DQT_HOST_PATH="$QT_HOST_PATH" \
             -DCMAKE_BUILD_TYPE=Release \
             -DBUILD_TESTS=OFF
 

--- a/.github/workflows/windows.yml
+++ b/.github/workflows/windows.yml
@@ -26,7 +26,7 @@ jobs:
           version: '6.7.3'
           host: 'windows'
           target: 'desktop'
-          arch: 'win64_msvc2022_64'
+          arch: 'win64_msvc2019_64'
           cache: true
 
       - name: Configure (MSVC)


### PR DESCRIPTION
Corrections des deux workflows suite aux échecs CI.

- **Windows** : `win64_msvc2022_64` → `win64_msvc2019_64` (Qt 6.7.x ne publie que des builds MSVC 2019)
- **Android** : installation Qt desktop séparée pour capturer `QT_HOST_PATH` avant l'install Android ; passage explicite de `Qt6_DIR` et `QT_HOST_PATH` à cmake

---
_Generated by [Claude Code](https://claude.ai/code/session_017ZMkpRE4LibVyGgeYZUgNK)_