### PR TITLE
Fix MSVC alternative tokens and Android Qt6 discovery

### DIFF
--- a/.github/workflows/android.yml
+++ b/.github/workflows/android.yml
@@ -64,6 +64,7 @@ jobs:
             -DCMAKE_TOOLCHAIN_FILE="$ANDROID_NDK_ROOT/build/cmake/android.toolchain.cmake" \
             -DANDROID_ABI=arm64-v8a \
             -DANDROID_PLATFORM=android-26 \
+            -DCMAKE_FIND_ROOT_PATH="$QT_ANDROID_ROOT" \
             -DCMAKE_PREFIX_PATH="$QT_ANDROID_ROOT" \
             -DQt6_DIR="$QT_ANDROID_ROOT/lib/cmake/Qt6" \
             -DQT_HOST_PATH="$QT_HOST_PATH" \

--- a/src/app/DesignPlan.cpp
+++ b/src/app/DesignPlan.cpp
@@ -34,7 +34,7 @@ DesignPlan::DesignPlan(QWidget* parent):QFrame(parent){
 }
 
 /*
- * A free area is an empty area such that the minimal distance between its points and all
+ * A free area is an empty area such that the minimal distance between its points && all
  * the neurons of the network is larger than 2 times the radius of a neuron.
  * If left button pressed in a free area then create a neuron
  * else select a neuron: if ctrl is holded than add to selection else only this neuron is selected.
@@ -55,7 +55,7 @@ void DesignPlan::mousePressEvent(QMouseEvent * event){
 
 	this->setFocus();
 	if(event->button() & Qt::LeftButton){
-		if (!(ctrl or alt or shift)){
+		if (!(ctrl || alt || shift)){
 			network->deselectAll();
 			// Those 7 lines ensure that two neurons'll never be drawn on the same place
 			// And select a neuron in case the cursor is on it.
@@ -74,7 +74,7 @@ void DesignPlan::mousePressEvent(QMouseEvent * event){
 			else{
 				s = network->getSynapse(event->x(), event->y());
 				if(s != nullptr){
-					s->setSelected(not s->getSelected());
+					s->setSelected(! s->getSelected());
 					emit synapseSelectedChanged(s);
 					currentSynapse = s;
 				}
@@ -91,7 +91,7 @@ void DesignPlan::mousePressEvent(QMouseEvent * event){
 				}
 			}
 		}
-		else if(ctrl and !(alt or shift)){
+		else if(ctrl && !(alt || shift)){
 			Neuron * n;
 			n = network->getNeuron(static_cast<int>((event->x() - transX)/scale), static_cast<int>((event->y() - transY)/scale), static_cast<int>(10/scale));
 			if(n != nullptr){
@@ -109,14 +109,14 @@ void DesignPlan::mousePressEvent(QMouseEvent * event){
 			else{
 				Synapse * s = network->getSynapse(event->x(), event->y());
 				if(s != nullptr){
-					s->setSelected(not s->getSelected());
+					s->setSelected(! s->getSelected());
 					emit synapseSelectedChanged(s);
 					currentSynapse = s;
 				}
 			}
 
 		}
-		else if(shift and !(alt or ctrl) and (currentUpdateBlock > -1)){
+		else if(shift && !(alt || ctrl) && (currentUpdateBlock > -1)){
 			Neuron * n;
 			n = network->getNeuron(static_cast<int>((event->x() - transX)/scale), static_cast<int>((event->y() - transY)/scale), static_cast<int>(10/scale));
 			if(n != nullptr){
@@ -164,7 +164,7 @@ void DesignPlan::mouseReleaseEvent(QMouseEvent * event){
 		midX = -1;
 		midY = -1;
 	}
-	else if((event->button() & Qt::RightButton) and (synapseBaseNeuron != nullptr)){
+	else if((event->button() & Qt::RightButton) && (synapseBaseNeuron != nullptr)){
 		Neuron * synapseFinalNeuron = network->getNeuron(static_cast<int>((event->x() - transX)/scale), static_cast<int>((event->y()- transY) / scale), static_cast<int>(10/scale));
 		if(synapseFinalNeuron != nullptr){
 			network->deselectAll();
@@ -234,7 +234,7 @@ void DesignPlan::keyPressEvent( QKeyEvent * event ){
 }
 
 /*
- * upload the mouse coordinate and the parameters of the translation.
+ * upload the mouse coordinate && the parameters of the translation.
  */
 void DesignPlan::mouseMoveEvent(QMouseEvent * event){
 	mouseX = event->x();
@@ -245,7 +245,7 @@ void DesignPlan::mouseMoveEvent(QMouseEvent * event){
 		dY = currentNeuron->getY() - (event->y()- transY)/scale;
 		currentNeuron->setXY((event->x()- transX)/scale, (event->y() - transY)/scale);
 		for(int i=0; i<network->getNbNeurons(); i++){
-			if((network->getNeuron(i)->getIndex()!=currentNeuron->getIndex()) and (network->getNeuron(i)->getSelected()))
+			if((network->getNeuron(i)->getIndex()!=currentNeuron->getIndex()) && (network->getNeuron(i)->getSelected()))
 				network->getNeuron(i)->setXY(network->getNeuron(i)->getX()-dX ,network->getNeuron(i)->getY()-dY);
 		}
 		emit networkIsModified();
@@ -271,7 +271,7 @@ void DesignPlan::mouseMoveEvent(QMouseEvent * event){
 }
 
 /*
- * Paint the network and a representation of the synapse the user is currently building.
+ * Paint the network && a representation of the synapse the user is currently building.
  */
 void DesignPlan::paintEvent(QPaintEvent * event){
 	QPainter painter(this);
@@ -385,7 +385,7 @@ void DesignPlan::setDefaultThresholds(const Neuron* neuron){
  */
 
 void DesignPlan::setDefaultThreshold(int stateIndex, double threshold){
-	if((stateIndex <= static_cast<int>(defaultThreshold.size())) and (stateIndex > 0)){
+	if((stateIndex <= static_cast<int>(defaultThreshold.size())) && (stateIndex > 0)){
 		defaultThreshold[stateIndex - 1] = threshold;
 	}
 }

--- a/src/app/EvenementHandler.cpp
+++ b/src/app/EvenementHandler.cpp
@@ -336,7 +336,7 @@ void EvenementHandler::pbStart_click(bool checked){
 		}
 	}
 
-	else if(parent->cmbSimulationType->currentText() == "Attractor and basins"){
+	else if(parent->cmbSimulationType->currentText() == "Attractor && basins"){
 		auto sim = std::make_unique<SimulationAttractorsAndBasinsOfAttraction>(computer.get());
 		auto myView = std::make_unique<UpdateBlock>();
 		for(int i=0; i < network->getNbNeurons();i++)
@@ -347,7 +347,7 @@ void EvenementHandler::pbStart_click(bool checked){
 		else if(parent->cmbScheduleType->currentText() == "Block Sequential"){ sim->setUpdateType(UpdateType::BS); sim->run(); }
 		else if(parent->cmbScheduleType->currentText() == "Sequential")      { sim->setUpdateType(UpdateType::S);  sim->run(); }
 	}
-	else if(parent->cmbSimulationType->currentText() == "Attractor and basins V2"){
+	else if(parent->cmbSimulationType->currentText() == "Attractor && basins V2"){
 		auto sim = std::make_unique<SimulationAttractorsAndBasinsOfAttraction2>(computer.get());
 		auto myView = std::make_unique<UpdateBlock>();
 		for(int i=0; i < network->getNbNeurons();i++)
@@ -370,7 +370,7 @@ void EvenementHandler::pbStart_click(bool checked){
 }
 
 /*
- * Stop the simulation and referesh the synapses
+ * Stop the simulation && referesh the synapses
  */
 void EvenementHandler::pbStop_click(bool checked){
 	for(int i=0; i < network->getNbNeurons(); i++){
@@ -379,8 +379,8 @@ void EvenementHandler::pbStop_click(bool checked){
 }
 
 /*
- * The value of the state radio button and the threshold are those of the latest selected neuron
- * And set the default state and threshold's value for futur neuron.
+ * The value of the state radio button && the threshold are those of the latest selected neuron
+ * And set the default state && threshold's value for futur neuron.
  */
 void EvenementHandler::neuronSelected(Neuron* neuron){
 
@@ -410,7 +410,7 @@ void EvenementHandler::neuronSelected(Neuron* neuron){
 
 /*
  * The value of the sbWeight is the value of the latest selected synapse
- * And set the default weight and delay values for the futur synapse.
+ * And set the default weight && delay values for the futur synapse.
  */
 void EvenementHandler::synapseSelected(Synapse* synapse){
 
@@ -465,7 +465,7 @@ QString EvenementHandler::getFileName() const{
 }
 
 /*
- * Switch between the network and the schedule design modes.
+ * Switch between the network && the schedule design modes.
  */
 void EvenementHandler::toolBox_currentChanged(int index){
 	if(parent->toolBox->itemText(index) == "Update schedule"){
@@ -692,7 +692,7 @@ void EvenementHandler::networkLayersMenu_aboutToShow(){
 				}
 			}
 			for(int j = 0; j< network->getNbNeurons(); j++){
-				if((minimals[j]>l1_distances[i]) and (minimals[j]!=network->getNbNeurons()))l1_distances[i] = minimals[j];
+				if((minimals[j]>l1_distances[i]) && (minimals[j]!=network->getNbNeurons()))l1_distances[i] = minimals[j];
 			}
 	}
 

--- a/src/app/NetworkDesignerParser.cpp
+++ b/src/app/NetworkDesignerParser.cpp
@@ -164,18 +164,18 @@ void NetworkDesignerParser::exportToGNBoxPremodel(QString fileName){
 			for(int j=0; j < network->getNbNeurons();j++){
 				interact = false;
 				k=0;
-				while((not interact) and (k < network->getNeuron(j)->getNb_neighbors())){
+				while((! interact) && (k < network->getNeuron(j)->getNb_neighbors())){
 					if(network->getNeuron(j)->getNeighbor(k)->getIndex() == i){
 						interact = true;
 						break;
 					}
 					k++;
 				}
-				if(interact and not putAComma){
+				if(interact && ! putAComma){
 					out << "i(x_" << j <<",1)";
 					putAComma = true;
 				}
-				else if (interact and putAComma)
+				else if (interact && putAComma)
 					out << ", i(x_" << j <<",1)";
 			}
 			if(i == network->getNbNeurons()-1)
@@ -262,14 +262,14 @@ void NetworkDesignerParser::exportToGNBoxPremodel(QString fileName){
 			for(int j=0; j < network->getNeuron(i)->getNb_neighbors() ;j++){
 				/*interact = false;
 				k=0;
-				while((not interact) and (k < network->getNeuron(j)->getNb_neighbors())){
+				while((! interact) && (k < network->getNeuron(j)->getNb_neighbors())){
 					if(network->getNeuron(j)->getNeighbor(k)->getIndex() == i){
 						interact = true;
 						break;
 					}
 					k++;
 				}*/
-				if(not putAComma){
+				if(! putAComma){
 					out << "i(x_" << network->getNeuron(i)->getSynapse(j)->getFinalNeuron()->getIndex() <<",1)";
 					putAComma = true;
 				}
@@ -295,7 +295,7 @@ void NetworkDesignerParser::exportToGNBoxPremodel(QString fileName){
 
 
 /*
- * This methods use Qt DOM to parse the network, the UpdateSchedulingPlan and the simulation.
+ * This methods use Qt DOM to parse the network, the UpdateSchedulingPlan && the simulation.
  * The first child of the root node is the network: the network contains neurons
  * Each neuron of the network is saved with its attributes.
  * The second child of the root node is the UpdateSchedulingPlan which is composed by UpdateBlocks
@@ -447,7 +447,7 @@ void NetworkDesignerParser::load(QString fileName){
 
 	Nb_Neurons = node.toElement().attribute("Nb_Neurons").toInt(&okki);
 	network = new Network(node.toElement().attribute("Temperature").toDouble(&okki));		// Read the Temperature parameter
-	network->setUniformalTemperature(static_cast<bool>(node.toElement().attribute("UniformalTemperature").toInt(&okki))); // Read if the temperature is uniform or note
+	network->setUniformalTemperature(static_cast<bool>(node.toElement().attribute("UniformalTemperature").toInt(&okki))); // Read if the temperature is uniform || note
 	if(Nb_Neurons>0){
 		for(int i=0; i < Nb_Neurons;i++)	network->addNeuron(new Neuron());
 		child = node.firstChild();											// Read neurons


### PR DESCRIPTION
- Sources : remplacement de `and`/`not`/`or` par `&&`/`!`/`||` — MSVC ne supporte pas les tokens alternatifs C++ sans `/Za` ou `iso646.h`
- `android.yml` : ajout de `CMAKE_FIND_ROOT_PATH` pour que `find_package(Qt6)` fonctionne sous le toolchain NDK qui impose `FIND_ROOT_PATH_MODE_PACKAGE=ONLY`

---
_Generated by [Claude Code](https://claude.ai/code/session_017ZMkpRE4LibVyGgeYZUgNK)_