### PR TITLE
Fix and/not/or in core files and Qt includes for cross-platform

### DIFF
--- a/src/app/networkdesigner.cpp
+++ b/src/app/networkdesigner.cpp
@@ -1,14 +1,14 @@
 #include "networkdesigner.h"
 #include "NetworkDesignerParser.h"
 #include "designplan.h"
-#include <QtWidgets/QMainWindow>
-#include <QtWidgets/QToolBar>
-#include <QtWidgets/QAction>
-#include <QtGui/QIcon>
-#include <QtWidgets/QLabel>
-#include <QtGui/QPixmap>
-#include <QtWidgets/QStatusBar>
-#include <QtWidgets/QApplication>
+#include <QMainWindow>
+#include <QToolBar>
+#include <QAction>
+#include <QIcon>
+#include <QLabel>
+#include <QPixmap>
+#include <QStatusBar>
+#include <QApplication>
 
 // Helper: load an SVG from Qt resources as a fixed-size QIcon.
 static QIcon svgIcon(const QString& path, int size = 20) {

--- a/src/core/network/Network.h
+++ b/src/core/network/Network.h
@@ -8,14 +8,14 @@ class Network
 {
 public:
 	
-	// Constructor and destructor
+	// Constructor && destructor
 	Network();
 	Network(double temperature);
 	Network(const Network& network);
 	void addNetwork(Network * network);
 	virtual ~Network();
 	
-	// Class's methods and functions
+	// Class's methods && functions
 	Neuron* getNeuron(int index) const;
 	//void computeBP(UpdateSchedulingPlan* sp, int nb_iterations, double synchronyRate);
 	//void computeBS(UpdateSchedulingPlan* sp, double synchronyRate);
@@ -24,7 +24,7 @@ public:
 	void delNeuron(int index);
 	int getState(bool* states) const; 
 	
-	// Attributes getters and setters 	
+	// Attributes getters && setters 	
 	int getNbNeurons() const;
 	
 	double getTemperature() const;

--- a/src/core/network/Neuron.cpp
+++ b/src/core/network/Neuron.cpp
@@ -210,9 +210,9 @@ void Neuron::compute2(double temperature){
 		std::vector<double> transitionProbabilities;		// Transition probabilities from state to others
 
 		sum.push_back(threshold[0] * state);
-		sum.push_back(threshold[0] * not(state));
+		sum.push_back(threshold[0] * !(state));
 		for(int i = 0; i < nb_neighbors; i++){
-			sum[0] += synapses[i]->getWeight() * (not synapses[i]->getStateOfTheFinalNeuron());
+			sum[0] += synapses[i]->getWeight() * (! synapses[i]->getStateOfTheFinalNeuron());
 			sum[1] += synapses[i]->getWeight() * synapses[i]->getStateOfTheFinalNeuron();
 		}
 
@@ -253,13 +253,13 @@ void Neuron::compute(double temperature){
 
 
 	if(temperature==0){
-		//if(index == 3 or index == 0) {theNewState = 1; hasANewState = true; return;}
+		//if(index == 3 || index == 0) {theNewState = 1; hasANewState = true; return;}
 		theNewState = 0;
 		double tmpSum = max;
 		for(int i=0; i<nbStates - 1;i++){
-			//printf("%d is %f >= %f and state is %d\n", index, tmpSum, sum[i], i+1);
+			//printf("%d is %f >= %f && state is %d\n", index, tmpSum, sum[i], i+1);
 			if((i+1) < (nbStates - 1)){
-				if(sum[i] >= 0 and sum[i+1] < 0){
+				if(sum[i] >= 0 && sum[i+1] < 0){
 					theNewState = i+1;
 					tmpSum = sum[i];
 					break;
@@ -271,7 +271,7 @@ void Neuron::compute(double temperature){
 				break;
 			}
 
-			/*if((sum[i] <= tmpSum) and (sum[i]>=0)){
+			/*if((sum[i] <= tmpSum) && (sum[i]>=0)){
 				theNewState = i+1;
 				tmpSum = sum[i];
 			}*/
@@ -305,7 +305,7 @@ void Neuron::compute(double temperature){
 		boltzmannTerm.push_back(0.0);			// Fictif boltzmann Term for calculus associated to the threshold of the N+1 state
 		// If we are in the state 0 we move up
 		// If we're in the last state we move down
-		// Else we randomly choose between going up or down
+		// Else we randomly choose between going up || down
 
 		if(state == 0)	rd1 = 0.1;
 		else if(state == nbStates - 1)	rd1 = 0.9;
@@ -334,7 +334,7 @@ void Neuron::compute(double temperature){
 			rd1 = Random::Uniform();
 			double s = 0;
 			int i = 0;
-			while((rd1>s) and (i+state < nbStates)){
+			while((rd1>s) && (i+state < nbStates)){
 				s+=transitionProbabilities[i];
 				i++;
 			}
@@ -359,7 +359,7 @@ void Neuron::compute(double temperature){
 			rd1 = Random::Uniform();
 			double s = 0;
 			int i = 0;
-			while((rd1>s) and (i<=state)){
+			while((rd1>s) && (i<=state)){
 				s+=transitionProbabilities[i];
 				i++;
 			}
@@ -367,7 +367,7 @@ void Neuron::compute(double temperature){
 		}
 
 	}
-		//	Moving up is prior but the probability of staying and moving to an upper state must be satisfied
+		//	Moving up is prior but the probability of staying && moving to an upper state must be satisfied
 	hasANewState = true;
 }
 

--- a/src/core/network/NeuronSynapse.h
+++ b/src/core/network/NeuronSynapse.h
@@ -11,7 +11,7 @@ class Neuron;
 class Synapse
 {
 public:
-	// Getters and Setters
+	// Getters && Setters
 	Synapse();
 	Synapse(Neuron * baseNeuron, Neuron * finalNeuron, double weight, int delay=0);
 	virtual ~Synapse();
@@ -63,7 +63,7 @@ private:
 class Neuron
 {
 public:
-	// Constructors and destructor
+	// Constructors && destructor
 	Neuron();
 	Neuron(int index);
 	//Neuron(int index, bool state);
@@ -72,7 +72,7 @@ public:
 	virtual ~Neuron();
 
 
-	// Getters and setters
+	// Getters && setters
 	int getIndex() const;
 	void setIndex(int index);
 
@@ -109,7 +109,7 @@ public:
 	bool getYellowMe() const;
 	void setYellowMe(bool yellowMe);
 
-	// Class's Methods and functions
+	// Class's Methods && functions
 	void compute(double temperature);
 	void compute2(double temperature);
 	void substitute();
@@ -145,7 +145,7 @@ protected:
 private:
 
 	int index;
-	int state;									// Active or not
+	int state;									// Active || !
 	int nbStates;
 	std::vector<double> threshold;
 	double temperature;
@@ -159,7 +159,7 @@ private:
 	int theNewState;							// The new state of the neuron
 
 	// Drawing parameters
-	double x, y;									// x and y in the widget coordinate system
+	double x, y;									// x && y in the widget coordinate system
 /*	int color[3];								// The color of the neuron in the RGB system
 	vector<int[3]> synapsesColor;				// Synapses colors in the RGB system
 */

--- a/src/core/network/Synapse.cpp
+++ b/src/core/network/Synapse.cpp
@@ -80,7 +80,7 @@ void Synapse::setSelected(bool selected){
 }
 
 /*
- * Build and draw the graphical representation (QPainterPath) of the arrow
+ * Build && draw the graphical representation (QPainterPath) of the arrow
  */
 void Synapse::drawMe(QPainter * painter, double scale, double transX, double transY){
 	
@@ -135,7 +135,7 @@ void Synapse::drawMe(QPainter * painter, double scale, double transX, double tra
 	// Updating
     gPath = rectPath;
     
-    if(baseNeuron->getSelected() and finalNeuron->getSelected()) selected = true;
+    if(baseNeuron->getSelected() && finalNeuron->getSelected()) selected = true;
     
     Qt::PenStyle myStyle;
     

--- a/src/core/scheduling/UpdateBlock.h
+++ b/src/core/scheduling/UpdateBlock.h
@@ -6,7 +6,7 @@
 class UpdateBlock
 {
 public:
-	// Constructor and destructor
+	// Constructor && destructor
 	UpdateBlock();
 	UpdateBlock(const UpdateBlock& updateBlock);
 	virtual ~UpdateBlock();
@@ -16,7 +16,7 @@ public:
 	void delNeuronIndex(int index);
 	void decrementGreaterThan(int index);
 
-	// Getters and setters
+	// Getters && setters
 	int getUpdateMethods() const;
 	void setUpdateMethods(int UpdateMethods);
 	int getSize() const;

--- a/src/core/scheduling/UpdateSchedulingPlan.h
+++ b/src/core/scheduling/UpdateSchedulingPlan.h
@@ -8,12 +8,12 @@ class UpdateSchedulingPlan
 
 public:
 
-	// Constructors and destuctors
+	// Constructors && destuctors
 	UpdateSchedulingPlan();
 	UpdateSchedulingPlan(const UpdateSchedulingPlan& updateSchedulingPlan);
 	virtual ~UpdateSchedulingPlan();
 
-	// Getters and setters
+	// Getters && setters
 	int getNb_blocks() const;
 	void addUpdateBlock(std::unique_ptr<UpdateBlock> ub);
 	void delUpdateBlock(int index);

--- a/src/core/simulation/Simulation.h
+++ b/src/core/simulation/Simulation.h
@@ -25,7 +25,7 @@ public:
 	Simulation();
 	virtual ~Simulation();
 
-	// name getter and setter
+	// name getter && setter
 	virtual std::string getName() const;
 	virtual void setName(std::string name);
 

--- a/src/core/simulation/SimulationAttractorsAndBasinsOfAttraction.cpp
+++ b/src/core/simulation/SimulationAttractorsAndBasinsOfAttraction.cpp
@@ -4,7 +4,7 @@
 
 SimulationAttractorsAndBasinsOfAttraction::SimulationAttractorsAndBasinsOfAttraction(Computer * computer):Simulation(computer)
 {
-	name = "Attractor and basins of attractions";
+	name = "Attractor && basins of attractions";
 	filepath = "simulation.gnu";
 	affinity = computer->getNetwork()->getNbNeurons() * 2;
 	numberOfIterations = computer->getNbIterations();
@@ -122,7 +122,7 @@ void SimulationAttractorsAndBasinsOfAttraction::run(){
 
 	/*if(test3 < test1) printf("test3 < test1\n");
 	else if(test1 < test3) printf("test3 > test1\n");
-	else printf("NO Relation between test3 and test1\n");
+	else printf("NO Relation between test3 && test1\n");
 
 	NetworkState testAtt(computer->getNetwork(), nbStates);
 	testAtt.setState(0,0);
@@ -145,7 +145,7 @@ void SimulationAttractorsAndBasinsOfAttraction::run(){
 	NetworkStatesSet * testMeNow = pBackward(aLitt);
 	*testMeNow -= *aLitt;
 	testMeNow->printMe();
-	printf("and in a compressed mode I am\n");
+	printf("&& in a compressed mode I am\n");
 	testMeNow->compress();
 	testMeNow->printMe();
 	delete testMeNow;
@@ -215,7 +215,7 @@ NetworkState * SimulationAttractorsAndBasinsOfAttraction::getRandomNetworkState(
 	double rnd;
 	for(int i=0; i < randomNetworkState->getSize(); i++){
 		rnd = Random::Uniform();
-		//if(i == 3 or i==0) randomNetworkState->setState(i, 1);
+		//if(i == 3 || i==0) randomNetworkState->setState(i, 1);
 		//else {
 			for(int j=0; j<randomNetworkState->getNbStates(i); j++){
 				if(rnd <= ((double)(j+1)/(double)(randomNetworkState->getNbStates(i)))){
@@ -350,7 +350,7 @@ NetworkStatesSet * SimulationAttractorsAndBasinsOfAttraction::pPredecessorOf(Net
 	if(!(x->coherent())) return new NetworkStatesSet(-1);
 
 	for(int i=0; i < computer->getNetwork()->getNbNeurons(); i++){
-		if(x->getState(i) >= 0 ){				// Temporary we suppose that the state is >=0 or equal to the superposition of all possible states
+		if(x->getState(i) >= 0 ){				// Temporary we suppose that the state is >=0 || equal to the superposition of all possible states
 			if(!(solutions[i]->getNetworkStatesSet(x->getState(i))->getFilled())){
 				solveAndStore(i);
 			}
@@ -426,7 +426,7 @@ void SimulationAttractorsAndBasinsOfAttraction::solveAndStore(int neuronIndex){
 			delete tmpNeuron;
 			return;
 		}
-		// begin by copying the neuron and all of his neighbors
+		// begin by copying the neuron && all of his neighbors
 		std::vector<Neuron*> neighbors;
 		NetworkState tmpNetworkState(computer->getNetwork(), nbStates);
 		NetworkStatesSet * allCombinations = new NetworkStatesSet(-1);
@@ -497,7 +497,7 @@ void SimulationAttractorsAndBasinsOfAttraction::solveAndStore(int neuronIndex){
 }
 
 /*
- * Backward till the stack a_traiter is empty or a allPossibleStates is riched
+ * Backward till the stack a_traiter is empty || a allPossibleStates is riched
  *
  */
 NetworkStatesSet * SimulationAttractorsAndBasinsOfAttraction::pBackward(NetworkStatesSet * attractor){
@@ -528,7 +528,7 @@ NetworkStatesSet * SimulationAttractorsAndBasinsOfAttraction::pBackward(NetworkS
 
 	while(a_traiter->getCardinal()>0){
 		currentNetworkState = a_traiter->getNetworkState(0);
-		if(a_traiter->getCardinal() != static_cast<int>(distances.size())) printf("not equal\n");
+		if(a_traiter->getCardinal() != static_cast<int>(distances.size())) printf("! equal\n");
 		currentDistance = distances[0];
 		if(currentDistance > maxDistance) maxDistance = currentDistance;
 		sumOfDistance += (currentDistance * currentNetworkState->getNbOfAllPossibleStates());

--- a/src/core/simulation/SimulationAttractorsAndBasinsOfAttraction2.cpp
+++ b/src/core/simulation/SimulationAttractorsAndBasinsOfAttraction2.cpp
@@ -16,7 +16,7 @@ SimulationAttractorsAndBasinsOfAttraction2::SimulationAttractorsAndBasinsOfAttra
 
 SimulationAttractorsAndBasinsOfAttraction2::SimulationAttractorsAndBasinsOfAttraction2(Computer * computer):Simulation(computer){
 	// TODO Auto-generated constructor stub
-	name = "Attractor and basins of attractions V2";
+	name = "Attractor && basins of attractions V2";
 	filepath = "simulation.gnu";
 	affinity = 100000;
 	computer->setNbIterations(1);
@@ -239,7 +239,7 @@ void SimulationAttractorsAndBasinsOfAttraction2::linkThem(int startingIndex){
 		computer->setProgressBarValue(static_cast<int>(100*((double)numberOfVisitedStates/(double)totalNumberOfStates)));
 		currentState->setNextOne(indexOf(nextState));
 
-		if((nextState->isVisited()) and !(nextState->isIsAttractor()) and (nextState->getAttractorNumber()==-1)){
+		if((nextState->isVisited()) && !(nextState->isIsAttractor()) && (nextState->getAttractorNumber()==-1)){
 			attractorFound(indexOf(nextState));
 			setAttractorNumber(startingIndex, attractors.size() - 1);
 		}

--- a/src/core/state/NetworkState.cpp
+++ b/src/core/state/NetworkState.cpp
@@ -106,7 +106,7 @@ NetworkState operator*(const NetworkState& lv, const NetworkState& rv){
 		rState = rv.getState(i);
 		if(myState == rState) result.setState(i, rState);
 		else{
-			if((myState == -1) or (rState == -1)) result.setState(i, -1);
+			if((myState == -1) || (rState == -1)) result.setState(i, -1);
 			else if((myState<0) && (rState<0)){
 				long int newState = ((-myState)&(-rState));
 				if(newState == 0) result.setState(i, -1);
@@ -158,7 +158,7 @@ int operator==(const NetworkState& lv, const NetworkState& rv){
 			else if((myState>=0) && (rState<0))
 				if(!(((long int)pow((double)2,myState)) && (-rState))) return false;
 			else if((myState<0) && (rState<0))
-				if(((-myState) && not(-rState)) or (not(-myState) && (-rState))) return false;
+				if(((-myState) && !(-rState)) || (!(-myState) && (-rState))) return false;
 		}
 	}
 	return true;
@@ -225,7 +225,7 @@ bool NetworkState::getDuplicated(){
 }
 
 /*
- * Return if a state is **....*...* or no.
+ * Return if a state is **....*...* || no.
  */
 int NetworkState::isAllPossibleStates() const{
 	for(int i=0; i < static_cast<int>(states.size()); i++){

--- a/src/core/state/NetworkStatesSet.cpp
+++ b/src/core/state/NetworkStatesSet.cpp
@@ -55,7 +55,7 @@ void NetworkStatesSet::addNetworkStatesSet(const NetworkStatesSet& networkStates
  */
 void NetworkStatesSet::addNetworkState(const NetworkState& networkState){
 
-	if((cardinal >= maxCardinal) and (maxCardinal>0)){
+	if((cardinal >= maxCardinal) && (maxCardinal>0)){
 		deleteOneElement(0);
 	}
 
@@ -102,7 +102,7 @@ void NetworkStatesSet::printMe() const{
 }
 
 void NetworkStatesSet::setMaxCardinal(int maxCardinal){
-	if((maxCardinal < cardinal) and (maxCardinal>=0)){
+	if((maxCardinal < cardinal) && (maxCardinal>=0)){
 		while(cardinal > maxCardinal) deleteOneElement(cardinal-1);		
 		cardinal = maxCardinal; 
 	}
@@ -117,7 +117,7 @@ void NetworkStatesSet::addAndCompress(const NetworkState& networkState){
 
 	
 	// Add a the networkState to the set
-	while((i < this->getCardinal()) and (!added)){
+	while((i < this->getCardinal()) && (!added)){
 		NetworkState tmpResult = *(this->getNetworkState(i)) + networkState;
 		if(tmpResult.coherent()){
 			added = true;
@@ -293,7 +293,7 @@ const NetworkStatesSet operator-(const NetworkStatesSet& lv, const NetworkState&
 const NetworkStatesSet operator*(const NetworkStatesSet& lv, const NetworkStatesSet& rv){
 	NetworkStatesSet result(-1);
 
-	if((lv.getCardinal() <=0) or (rv.getCardinal() <=0)) {
+	if((lv.getCardinal() <=0) || (rv.getCardinal() <=0)) {
 		return result;
 	}
 	/*result = lv - (lv -rv);
@@ -312,7 +312,7 @@ const NetworkStatesSet operator*(const NetworkStatesSet& lv, const NetworkStates
 /*
  * When using pseudo state: a state minus a state is the deleting the possibilitier that the left
  * operand is equivalent to the right one if !!!!!!the operation is permitted!!!!!!! .ie
- * if there is a relation of equivalence or order between the two NetworkState s
+ * if there is a relation of equivalence || order between the two NetworkState s
  * 
  */
  
@@ -327,7 +327,7 @@ const NetworkStatesSet operator*(const NetworkStatesSet& lv, const NetworkStates
 	int index=0;
 	int count = 0;
 	
-	if(!(lv.coherent() or rv.coherent())) return result;	
+	if(!(lv.coherent() || rv.coherent())) return result;	
 	modified = true;
 	bool incoherent;
 	index = -1;
@@ -336,14 +336,14 @@ const NetworkStatesSet operator*(const NetworkStatesSet& lv, const NetworkStates
 		modified = false;
 		incoherent = false;	
 		for(int i=0; i < lv.getSize(); i++){
-			if(lv.getState(i) != rv.getState(i) and lv.getState(i) >=0 and rv.getState(i) >=0){
-					if((lv.getState(i) >= 0) and (rv.getState(i) >= 0)){
+			if(lv.getState(i) != rv.getState(i) && lv.getState(i) >=0 && rv.getState(i) >=0){
+					if((lv.getState(i) >= 0) && (rv.getState(i) >= 0)){
 						while(result.getCardinal() > 0) result.removeNetworkState(0);
 						result.addNetworkState(lv);
 						return result;
 					}
 			} 
-			else if((i > index) and not modified){
+			else if((i > index) && ! modified){
 				modified = true;
 				index = i;
 				if(lv.getState(i)<-1)  leftValue = -lv.getState(i);
@@ -365,7 +365,7 @@ const NetworkStatesSet operator*(const NetworkStatesSet& lv, const NetworkStates
 					globalModified = true;
 				}
 			}
-			else if(not modified and i <= index){
+			else if(! modified && i <= index){
 				if(lv.getState(i)<-1)  leftValue = -lv.getState(i);
 				else if(lv.getState(i)>-1) leftValue = (long int)pow(2.0, (double) lv.getState(i));
 				
@@ -384,7 +384,7 @@ const NetworkStatesSet operator*(const NetworkStatesSet& lv, const NetworkStates
 			}	
              
 		}
-		if(modified and not incoherent) result.addNetworkState(tmpNetworkState); 
+		if(modified && ! incoherent) result.addNetworkState(tmpNetworkState); 
 	}
 	return result;
 }

--- a/src/core/state/NetworkStatesSet.h
+++ b/src/core/state/NetworkStatesSet.h
@@ -32,14 +32,14 @@ public:
 	void compress();
 	void removeDuplications();
 	
-	// Extern and friendly Opertators
+	// Extern && friendly Opertators
 	friend const NetworkStatesSet operator+(const NetworkStatesSet& lv, const NetworkStatesSet& rv);
 	friend const NetworkStatesSet operator*(const NetworkStatesSet& lv, const NetworkStatesSet& rv);
 
 	friend const NetworkStatesSet operator-(const NetworkStatesSet& lv, const NetworkStatesSet& rv);
 	friend const NetworkStatesSet operator-(const NetworkStatesSet& lv, const NetworkState& rv);	
 	
-	// Member increment and decrement operators
+	// Member increment && decrement operators
 	void operator+=(const NetworkState& rv);
 	void operator-=(const NetworkState& rv);
 	void operator*=(const NetworkState& rv);

--- a/src/core/utils/random-singleton.cpp
+++ b/src/core/utils/random-singleton.cpp
@@ -87,7 +87,7 @@ double Random::theRandom(void)
 //fin theRandom()
 
 //Renvoie un double de la Gaussienne de moyenne et d'ecartype specifies
-//Returns a double taken on a Gaussian with specified mean and standard deviation
+//Returns a double taken on a Gaussian with specified mean && standard deviation
 double Random::Gaussian(double mean, double standardDeviation)
 {
   const int NbTirages = 12; //augmenter pour une meilleure precision. 12 est bien.
@@ -102,7 +102,7 @@ double Random::Gaussian(double mean, double standardDeviation)
   //on etale suivant l'ecartype / spread with standard deviation
   //le 12 n'a rien a voir avec NbTirages, mais explique pourquoi justement, on prend souvent
   //NbTirages = 12
-  //the 12 is not related to NbTirages, but it explains why it is often chosen that NbTirages=12
+  //the 12 is ! related to NbTirages, but it explains why it is often chosen that NbTirages=12
   valeur *= (NbTirages == 12) ? standardDeviation
                               : sqrt(12/static_cast<double>(NbTirages))*standardDeviation;
 

--- a/src/core/utils/random-singleton.h
+++ b/src/core/utils/random-singleton.h
@@ -25,13 +25,13 @@ class Random //Singleton
   public:
     //Reinitialise la graine / Inits the seed
     //Attention, 0 et 1 pour la graine donnent la meme suite
-    //Beware that 0 and 1 for the seed give the same sequence
+    //Beware that 0 && 1 for the seed give the same sequence
     static void Randomize(long thatSeed=0);
 
     //Pour un type T, renvoie une valeur uniformement dans [min;max]
     //(min et max exclu pour les types non entiers)
     //For a type T, returns a value uniformly in [min;max]
-    //(min and max excluded for non integral types)
+    //(min && max excluded for non integral types)
     template <typename T>
     static inline T Uniform(T min, T max)
            {return min+static_cast<T>((max+(typeIsInteger<T>()?1:0)-min)*theRandom());}
@@ -41,7 +41,7 @@ class Random //Singleton
 
     //Renvoie un nombre selon la Gaussienne de moyenne et d'ecartype specifies
     //Par defaut, c'est la loi normale centree reduite
-    //Returns a double taken on a Gaussian with specified mean and standard dev.
+    //Returns a double taken on a Gaussian with specified mean && standard dev.
     //By default, it is the Normal law with mean=0, std dev=1
     static double Gaussian(double mean=0, double standardDeviation=1);
 


### PR DESCRIPTION
- `src/core/` : remplacement complet de `and`/`not`/`or` par `&&`/`!`/`||` dans Neuron.cpp, Synapse.cpp, NetworkState.cpp, NetworkStatesSet.cpp, SimulationAttractorsAndBasinsOfAttraction2.cpp
- `networkdesigner.cpp` : remplacement de `<QtWidgets/QFoo>` / `<QtGui/QFoo>` par `<QFoo>` (includes plats) — forme supportée sur toutes les plateformes y compris le cross-compile Android

---
_Generated by [Claude Code](https://claude.ai/code/session_017ZMkpRE4LibVyGgeYZUgNK)_