### PR TITLE
Windows & Android CI builds

### DIFF
--- a/.github/workflows/android.yml
+++ b/.github/workflows/android.yml
@@ -62,9 +62,9 @@ jobs:
 
       - name: Remove broken preview Android platforms
         run: |
-          # android-36-ext19 has a corrupt android.jar that breaks aapt2
-          rm -rf "$ANDROID_SDK_ROOT/platforms/android-36-ext19" || true
-          rm -rf "$ANDROID_SDK_ROOT/platforms/android-36" || true
+          # All android-36 variants (ext18, ext19, ...) have corrupt android.jar
+          rm -rf "$ANDROID_SDK_ROOT/platforms"/android-36* || true
+          ls "$ANDROID_SDK_ROOT/platforms/"
 
       # Install both Qt variants via aqt for predictable, fixed paths
       - name: Install aqt

--- a/.github/workflows/android.yml
+++ b/.github/workflows/android.yml
@@ -60,6 +60,12 @@ jobs:
           sdkmanager "ndk;${{ env.ANDROID_NDK_VERSION }}" "platforms;android-33" "build-tools;33.0.2"
           echo "ANDROID_NDK_ROOT=$ANDROID_SDK_ROOT/ndk/${{ env.ANDROID_NDK_VERSION }}" >> $GITHUB_ENV
 
+      - name: Remove broken preview Android platforms
+        run: |
+          # android-36-ext19 has a corrupt android.jar that breaks aapt2
+          rm -rf "$ANDROID_SDK_ROOT/platforms/android-36-ext19" || true
+          rm -rf "$ANDROID_SDK_ROOT/platforms/android-36" || true
+
       # Install both Qt variants via aqt for predictable, fixed paths
       - name: Install aqt
         run: pip install aqtinstall

--- a/.github/workflows/android.yml
+++ b/.github/workflows/android.yml
@@ -60,10 +60,13 @@ jobs:
           sdkmanager "ndk;${{ env.ANDROID_NDK_VERSION }}" "platforms;android-33" "build-tools;33.0.2"
           echo "ANDROID_NDK_ROOT=$ANDROID_SDK_ROOT/ndk/${{ env.ANDROID_NDK_VERSION }}" >> $GITHUB_ENV
 
-      - name: Remove broken preview Android platforms
+      - name: Keep only android-33 platform
         run: |
-          # All android-36 variants (ext18, ext19, ...) have corrupt android.jar
-          rm -rf "$ANDROID_SDK_ROOT/platforms"/android-36* || true
+          # All ext preview platforms (android-35-extXX, android-36-extXX, etc)
+          # installed by setup-android have corrupt android.jar — remove everything
+          # except the android-33 we just installed explicitly.
+          find "$ANDROID_SDK_ROOT/platforms" -mindepth 1 -maxdepth 1 \
+            ! -name "android-33" -exec rm -rf {} +
           ls "$ANDROID_SDK_ROOT/platforms/"
 
       # Install both Qt variants via aqt for predictable, fixed paths

--- a/.github/workflows/android.yml
+++ b/.github/workflows/android.yml
@@ -105,26 +105,15 @@ jobs:
       - name: Build
         run: cmake --build build-android --parallel
 
-      - name: Package APK with androiddeployqt
-        run: |
-          DEPLOY_JSON=$(find build-android -name "android-NetworkDesigner-deployment-settings.json" | head -1)
-          if [ -z "$DEPLOY_JSON" ]; then
-            echo "Deployment JSON not found, listing build-android:"
-            find build-android -name "*.json" | head -20
-            exit 1
-          fi
-          echo "Using deployment JSON: $DEPLOY_JSON"
-          "$QT_ANDROID_ROOT/bin/androiddeployqt" \
-            --input "$DEPLOY_JSON" \
-            --output build-android/android-build \
-            --android-platform android-34 \
-            --jdk "$JAVA_HOME" \
-            --apk
-
       - name: Locate APK
         id: find-apk
         run: |
-          APK=$(find build-android/android-build -name "*.apk" | head -1)
+          APK=$(find build-android -name "*.apk" | head -1)
+          if [ -z "$APK" ]; then
+            echo "APK not found, listing build-android outputs:"
+            find build-android -name "*.apk" -o -name "*.aab" 2>/dev/null | head -20
+            exit 1
+          fi
           echo "Found APK: $APK"
           echo "apk_path=$APK" >> $GITHUB_OUTPUT
 

--- a/.github/workflows/android.yml
+++ b/.github/workflows/android.yml
@@ -89,6 +89,7 @@ jobs:
             -DCMAKE_PREFIX_PATH="$QT_ANDROID_ROOT" \
             -DQt6_DIR="$QT_ANDROID_ROOT/lib/cmake/Qt6" \
             -DQT_HOST_PATH="$QT_HOST_PATH" \
+            -DANDROID_SDK_ROOT="$ANDROID_SDK_ROOT" \
             -DCMAKE_BUILD_TYPE=Release \
             -DBUILD_TESTS=OFF
 

--- a/.github/workflows/android.yml
+++ b/.github/workflows/android.yml
@@ -2,19 +2,40 @@ name: Android – Build APK
 
 on:
   push:
-    branches: [master, claude/networkdesigner-windows-mobile-kgdpz3]
+    branches: [master]
   pull_request:
     branches: [master]
   workflow_dispatch:
     inputs:
+      build:
+        description: 'Run build (required to trigger on feature branches)'
+        type: boolean
+        default: false
       create_release:
         description: 'Create GitHub Release'
         type: boolean
         default: false
 
 jobs:
+  check:
+    runs-on: ubuntu-latest
+    outputs:
+      should_build: ${{ steps.decide.outputs.should_build }}
+    steps:
+      - id: decide
+        run: |
+          if [[ "${{ github.ref }}" == "refs/heads/master" || "${{ github.event_name }}" == "pull_request" ]]; then
+            echo "should_build=true" >> $GITHUB_OUTPUT
+          elif [[ "${{ github.event_name }}" == "workflow_dispatch" && "${{ inputs.build }}" == "true" ]]; then
+            echo "should_build=true" >> $GITHUB_OUTPUT
+          else
+            echo "should_build=false" >> $GITHUB_OUTPUT
+          fi
+
   build-android:
     name: Build APK (arm64-v8a, Qt6)
+    needs: check
+    if: needs.check.outputs.should_build == 'true'
     runs-on: ubuntu-latest
 
     env:

--- a/.github/workflows/android.yml
+++ b/.github/workflows/android.yml
@@ -55,9 +55,9 @@ jobs:
       - name: Set up Android SDK
         uses: android-actions/setup-android@v3
 
-      - name: Install NDK
+      - name: Install NDK and platform 33
         run: |
-          sdkmanager "ndk;${{ env.ANDROID_NDK_VERSION }}"
+          sdkmanager "ndk;${{ env.ANDROID_NDK_VERSION }}" "platforms;android-33" "build-tools;33.0.2"
           echo "ANDROID_NDK_ROOT=$ANDROID_SDK_ROOT/ndk/${{ env.ANDROID_NDK_VERSION }}" >> $GITHUB_ENV
 
       # Install both Qt variants via aqt for predictable, fixed paths

--- a/.github/workflows/android.yml
+++ b/.github/workflows/android.yml
@@ -55,18 +55,18 @@ jobs:
       - name: Set up Android SDK
         uses: android-actions/setup-android@v3
 
-      - name: Install NDK and platform 33
+      - name: Install NDK and platform 34
         run: |
-          sdkmanager "ndk;${{ env.ANDROID_NDK_VERSION }}" "platforms;android-33" "build-tools;33.0.2"
+          sdkmanager "ndk;${{ env.ANDROID_NDK_VERSION }}" "platforms;android-34" "build-tools;34.0.0"
           echo "ANDROID_NDK_ROOT=$ANDROID_SDK_ROOT/ndk/${{ env.ANDROID_NDK_VERSION }}" >> $GITHUB_ENV
 
-      - name: Keep only android-33 platform
+      - name: Keep only android-34 platform
         run: |
           # All ext preview platforms (android-35-extXX, android-36-extXX, etc)
           # installed by setup-android have corrupt android.jar — remove everything
-          # except the android-33 we just installed explicitly.
+          # except the android-34 we just installed explicitly.
           find "$ANDROID_SDK_ROOT/platforms" -mindepth 1 -maxdepth 1 \
-            ! -name "android-33" -exec rm -rf {} +
+            ! -name "android-34" -exec rm -rf {} +
           ls "$ANDROID_SDK_ROOT/platforms/"
 
       # Install both Qt variants via aqt for predictable, fixed paths
@@ -117,7 +117,7 @@ jobs:
           "$QT_ANDROID_ROOT/bin/androiddeployqt" \
             --input "$DEPLOY_JSON" \
             --output build-android/android-build \
-            --android-platform android-33 \
+            --android-platform android-34 \
             --jdk "$JAVA_HOME" \
             --apk
 

--- a/.github/workflows/windows.yml
+++ b/.github/workflows/windows.yml
@@ -105,7 +105,7 @@ jobs:
           $script | Out-File -Encoding UTF8 installer.nsi
 
       - name: Build installer
-        run: makensis installer.nsi
+        run: '& "C:\Program Files (x86)\NSIS\makensis.exe" installer.nsi'
 
       - name: Upload installer artifact
         uses: actions/upload-artifact@v4

--- a/.github/workflows/windows.yml
+++ b/.github/workflows/windows.yml
@@ -2,19 +2,40 @@ name: Windows – Build & Installer
 
 on:
   push:
-    branches: [master, claude/networkdesigner-windows-mobile-kgdpz3]
+    branches: [master]
   pull_request:
     branches: [master]
   workflow_dispatch:
     inputs:
+      build:
+        description: 'Run build (required to trigger on feature branches)'
+        type: boolean
+        default: false
       create_release:
         description: 'Create GitHub Release'
         type: boolean
         default: false
 
 jobs:
+  check:
+    runs-on: ubuntu-latest
+    outputs:
+      should_build: ${{ steps.decide.outputs.should_build }}
+    steps:
+      - id: decide
+        run: |
+          if [[ "${{ github.ref }}" == "refs/heads/master" || "${{ github.event_name }}" == "pull_request" ]]; then
+            echo "should_build=true" >> $GITHUB_OUTPUT
+          elif [[ "${{ github.event_name }}" == "workflow_dispatch" && "${{ inputs.build }}" == "true" ]]; then
+            echo "should_build=true" >> $GITHUB_OUTPUT
+          else
+            echo "should_build=false" >> $GITHUB_OUTPUT
+          fi
+
   build-windows:
     name: Build (Windows, Qt5 MSVC)
+    needs: check
+    if: needs.check.outputs.should_build == 'true'
     runs-on: windows-latest
 
     steps:

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -35,12 +35,21 @@ set(APP_FORMS
     app/networkdesigner.ui
 )
 
-add_executable(NetworkDesigner
-    ${CORE_SOURCES}
-    ${APP_SOURCES}
-    ${APP_FORMS}
-    ${CMAKE_SOURCE_DIR}/resources/resources.qrc
-)
+if(QT_VERSION_MAJOR EQUAL 6)
+    qt_add_executable(NetworkDesigner
+        ${CORE_SOURCES}
+        ${APP_SOURCES}
+        ${APP_FORMS}
+        ${CMAKE_SOURCE_DIR}/resources/resources.qrc
+    )
+else()
+    add_executable(NetworkDesigner
+        ${CORE_SOURCES}
+        ${APP_SOURCES}
+        ${APP_FORMS}
+        ${CMAKE_SOURCE_DIR}/resources/resources.qrc
+    )
+endif()
 
 target_include_directories(NetworkDesigner PRIVATE
     ${CMAKE_CURRENT_SOURCE_DIR}/core/network

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -72,4 +72,6 @@ set_target_properties(NetworkDesigner PROPERTIES
     MACOSX_BUNDLE TRUE
 )
 
-install(TARGETS NetworkDesigner RUNTIME DESTINATION bin)
+if(NOT ANDROID)
+    install(TARGETS NetworkDesigner RUNTIME DESTINATION bin)
+endif()

--- a/src/core/network/Neuron.cpp
+++ b/src/core/network/Neuron.cpp
@@ -503,7 +503,7 @@ Synapse * Neuron::getSelfSynapse() const{
 void Neuron::delSynapseBySynapseIndex(int synapseIndex){
 	if(synapseIndex < nb_neighbors)
 	{
-			synapses.erase((std::vector<Synapse*>::iterator)&synapses[synapseIndex]);
+			synapses.erase(synapses.begin() + synapseIndex);
 			nb_neighbors--;
 	}
 }

--- a/src/core/simulation/SimulationAttractorsAndBasinsOfAttraction2.cpp
+++ b/src/core/simulation/SimulationAttractorsAndBasinsOfAttraction2.cpp
@@ -319,7 +319,7 @@ NetworkState * SimulationAttractorsAndBasinsOfAttraction2::getNbStates() const{
 }
 
 int * SimulationAttractorsAndBasinsOfAttraction2::getSizeOfBasins() const{
-
+	return nullptr;
 }
 
 double** SimulationAttractorsAndBasinsOfAttraction2::getMTransitions() const{


### PR DESCRIPTION
## Summary

- Add Windows CI workflow: Qt5 MSVC build + NSIS installer artifact
- Add Android CI workflow: Qt6 arm64-v8a APK artifact
- Both workflows auto-run on master/PRs to master; manual trigger (with `build=true`) on feature branches
- Fix MSVC C2440: replace illegal C-style pointer-to-iterator cast in `Neuron.cpp`
- Fix MSVC C4716: add missing `return nullptr` in `getSizeOfBasins()`
- Use `qt_add_executable` for Qt6 (required to generate Android deployment JSON)
- Skip `install()` on Android (Qt6 Android target is a shared library, not a binary)
- Use android-34 platform (androidx.core:1.13.1 requires compileSdk ≥ 34)
- Remove broken ext-preview platforms installed by setup-android@v3
- Drop redundant manual `androiddeployqt` step — cmake's `apk` target handles it

---
_Generated by [Claude Code](https://claude.ai/code/session_017ZMkpRE4LibVyGgeYZUgNK)_