### PR TITLE
fix(android): align targetSdkVersion to 34

### DIFF
--- a/android/AndroidManifest.xml
+++ b/android/AndroidManifest.xml
@@ -6,7 +6,7 @@
 
     <uses-sdk
         android:minSdkVersion="26"
-        android:targetSdkVersion="33" />
+        android:targetSdkVersion="34" />
 
     <!-- Storage access for saving/loading .nml files -->
     <uses-permission android:name="android.permission.READ_EXTERNAL_STORAGE"


### PR DESCRIPTION
targetSdkVersion was 33 while compileSdkVersion is 34 — align them to avoid inconsistency warnings and potential runtime issues.

---
_Generated by [Claude Code](https://claude.ai/code/session_017ZMkpRE4LibVyGgeYZUgNK)_