### PR TITLE
fix(android): disable lastWindowClosed→quit on Android

### DIFF
--- a/src/app/main.cpp
+++ b/src/app/main.cpp
@@ -10,6 +10,11 @@ int main(int argc, char *argv[])
     QApplication a(argc, argv);
     NetworkDesigner w;
     w.show();
+#ifndef Q_OS_ANDROID
+    // On Android the Activity manages the lifecycle; connecting lastWindowClosed
+    // to quit() causes the app to exit immediately when the system briefly
+    // takes focus during startup.
     a.connect(&a, &QApplication::lastWindowClosed, &a, &QApplication::quit);
+#endif
     return a.exec();
 }


### PR DESCRIPTION
On Android the Activity manages the app lifecycle. Connecting `lastWindowClosed` to `QApplication::quit()` causes the app to exit immediately when the system briefly steals focus during startup — the classic "window appears for a fraction of a second then closes" symptom on Qt Widgets Android apps.

---
_Generated by [Claude Code](https://claude.ai/code/session_017ZMkpRE4LibVyGgeYZUgNK)_