### PR TITLE
fix(android): replace repaint() with update() in updateMe()

### DIFF
--- a/src/app/EvenementHandler.cpp
+++ b/src/app/EvenementHandler.cpp
@@ -67,7 +67,7 @@ void EvenementHandler::updateMe(){
 	}
 	emit temperatureChanged(network->getTemperature());
 	emit neuronTemperatureChanged(network->getTemperature());
-	parent->frmDesign->parentWidget()->repaint();
+	parent->frmDesign->parentWidget()->update();
 	if(network->getUniformalTemperature())	parent->chkUniformalTemperature->setCheckState(Qt::Checked);
 	else					parent->chkUniformalTemperature->setCheckState(Qt::Unchecked);
 	// Refreshing the cmbUpdateBlock


### PR DESCRIPTION
On Android, `repaint()` called during construction (before the native window surface exists) can crash. Replaced with `update()` which defers painting to the event loop.

---
_Generated by [Claude Code](https://claude.ai/code/session_017ZMkpRE4LibVyGgeYZUgNK)_